### PR TITLE
Make confirm button blue, not red

### DIFF
--- a/Source/Turbo/Navigator/WKUIController.swift
+++ b/Source/Turbo/Navigator/WKUIController.swift
@@ -22,7 +22,7 @@ open class WKUIController: NSObject, WKUIDelegate {
 
     open func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
         let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .destructive) { _ in
+        alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
             completionHandler(true)
         })
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in


### PR DESCRIPTION
This PR changes the non-cancel button of the confirmation dialog from "destructive" (red) to "default" (blue), which covers more use-cases.

This is triggered with JavaScript via `alert("Proceed with this action?"). Further customization should be done by subclassing `WKUIController` or using a bridge component.

| Before | After |
| ------ | ----- |
| ![RocketSim_Screenshot_iPhone_15_Pro_6 1_2024-05-15_15 13 23](https://github.com/hotwired/hotwire-native-ios/assets/2092156/140be0b5-5afe-4d3f-8014-e2b17a178c2f) | ![RocketSim_Screenshot_iPhone_15_Pro_6 1_2024-05-15_15 12 14](https://github.com/hotwired/hotwire-native-ios/assets/2092156/9b185562-0faf-4d57-a53e-7a3a5bf75e27) |