### PR TITLE
Fix authentication flow in demo app

### DIFF
--- a/Demo/Demo.swift
+++ b/Demo/Demo.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct Demo {
-    static let remote = URL(string: "https://hotwire-native-demo.dev/")!
+    static let remote = URL(string: "https://hotwire-native-demo.dev")!
     static let local = URL(string: "http://localhost:45678")!
 
     /// Update this to choose which demo is run

--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -70,4 +70,18 @@ extension SceneController: NavigatorDelegate {
             return .acceptCustom(HotwireWebViewController(url: proposal.url))
         }
     }
+
+    func visitableDidFailRequest(_ visitable: any Visitable, error: any Error, retryHandler: RetryBlock?) {
+        if let turboError = error as? TurboError, case let .http(statusCode) = turboError, statusCode == 401 {
+            promptForAuthentication()
+        } else if let errorPresenter = visitable as? ErrorPresenter {
+            errorPresenter.presentError(error) {
+                retryHandler?()
+            }
+        } else {
+            let alert = UIAlertController(title: "Visit failed!", message: error.localizedDescription, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            navigator.rootViewController.present(alert, animated: true)
+        }
+    }
 }


### PR DESCRIPTION
When migrating from turbo-ios, `visitableDidFailRequest(_:error:retryHandler:)` was left behind. This PR adds that back in which fixes the authentication flow when hitting a 401.
