### PR TITLE
fix: VisitableView NavigationBar glitch

### DIFF
--- a/Source/Turbo/Visitable/VisitableView.swift
+++ b/Source/Turbo/Visitable/VisitableView.swift
@@ -24,7 +24,7 @@ open class VisitableView: UIView {
     open func activateWebView(_ webView: WKWebView, forVisitable visitable: Visitable) {
         self.webView = webView
         self.visitable = visitable
-        addSubview(webView)
+        insertSubview(webView, belowSubview: activityIndicatorView)
         addFillConstraints(for: webView)
         installRefreshControl()
         showOrHideWebView()
@@ -68,7 +68,7 @@ open class VisitableView: UIView {
         guard let scrollView = webView?.scrollView, allowsPullToRefresh else { return }
 
         #if !targetEnvironment(macCatalyst)
-        scrollView.addSubview(refreshControl)
+        scrollView.insertSubview(refreshControl, belowSubview: webView!)
 
         /// Infer refresh control's default height from its frame, if given.
         /// Otherwise fallback to 60 (the default height).
@@ -155,7 +155,12 @@ open class VisitableView: UIView {
     open func showScreenshot() {
         guard !isShowingScreenshot, !isRefreshing else { return }
 
-        addSubview(screenshotContainerView)
+        if let webView = webView {
+            insertSubview(screenshotContainerView, aboveSubview: webView)
+        } else {
+            addSubview(screenshotContainerView)
+        }
+        
         addFillConstraints(for: screenshotContainerView)
         showOrHideWebView()
     }


### PR DESCRIPTION
Hello,

I believe this is fixing the NavigationBar glitches described in https://github.com/hotwired/turbo-ios/issues/196.
It’s still not perfect when using large titles but otherwise it seems to do the trick.

This PR is just changing the way we insert Subviews in the VisitableView.swift file to make sure they are always inserted the way we want.