### PR TITLE
Fix `animated` flag from path configuration

### DIFF
--- a/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
@@ -62,7 +62,7 @@ public extension VisitProposal {
 
     /// Allows the proposal to change the animation status when pushing, popping or presenting.
     var animated: Bool {
-        if let animated = parameters?["animated"] as? Bool {
+        if let animated = properties["animated"] as? Bool {
             return animated
         }
 


### PR DESCRIPTION
This PR addresses a mistake noticed by @mrfidgety in the [turbo-ios repo](https://github.com/hotwired/turbo-ios/pull/158#pullrequestreview-2329794028). We were looking for the `animated` flag in the `parameters` but it should appear in `properties` because it comes from the path configuration.

This PR fixes that typo.