### PR TITLE
Expose `Session.reload()` on Navigator

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -76,9 +76,10 @@ public class Navigator {
         hierarchyController.clearAll(animated: animated)
     }
 
-    /// Reloads the main `Session`.
+    /// Reloads the main and modal `Session`.
     public func reload() {
         session.reload()
+        modalSession.reload()
     }
 
     /// Navigate to an external URL.

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -76,6 +76,11 @@ public class Navigator {
         hierarchyController.clearAll(animated: animated)
     }
 
+    /// Reloads the main `Session`.
+    public func reload() {
+        session.reload()
+    }
+
     /// Navigate to an external URL.
     ///
     /// - Parameters:


### PR DESCRIPTION
This PR exposes `reload()` on the main `Session`. When working with tabs, it's helpful to be able to manually reload screens after the user signs in or out.