### PR TITLE
Fix parameters in route

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -47,7 +47,7 @@ public class Navigator {
     /// - Parameter parameters: provide context relevant to `url`
     public func route(_ url: URL, options: VisitOptions? = VisitOptions(action: .advance), parameters: [String: Any]? = nil) {
         let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
-        route(VisitProposal(url: url, options: options ?? .init(action: .advance), properties: properties))
+        route(VisitProposal(url: url, options: options ?? .init(action: .advance), properties: properties, parameters: parameters))
     }
 
     /// Transforms `VisitProposal` -> `UIViewController`


### PR DESCRIPTION
`parameters` argument is missing [here](https://github.com/hotwired/hotwire-native-ios/blob/3ba9441959ead175e7b5220abbaf8f18a79bff72/Source/Turbo/Navigator/Navigator.swift#L50). This causes `parameters` not being retained in `handle(proposal: VisitProposal)`.

````swift
// For example, parameters passed in below function call
navigator.route(
    rootUrl.appendingPathComponent("/auth/enter-otp"),
    options: VisitOptions(action: .advance),
    parameters: ["mobileNumber": enternedMobileNumber]
)
 
extension SceneDelegate: NavigatorDelegate {
    func handle(proposal: VisitProposal) -> ProposalResult {
       // are not received here in proposal.parameters
    }
}
````

It was added in this [commit](https://github.com/hotwired/hotwire-native-ios/commit/958fcd8bb9e6ca4005822cd39374caf0828d5c6a#diff-48abac57e64de24f576c380309b9a2867a8f9a9bc088090848bc3fbf7f6e1a47L48) but removed in this [commit](https://github.com/hotwired/hotwire-native-ios/commit/981d6975e2b2fe3c583971c75e05050c93dee5c2#diff-48abac57e64de24f576c380309b9a2867a8f9a9bc088090848bc3fbf7f6e1a47L49). I think this was mistakenly removed.

