### PR TITLE
Move `registerBridgeComponents` to `AppDelegate` in the Demo app

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -6,6 +6,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Hotwire.config.backButtonDisplayMode = .minimal
         Hotwire.config.showDoneButtonOnModals = true
+        Hotwire.registerBridgeComponents([
+            FormComponent.self,
+            MenuComponent.self,
+            OverflowMenuComponent.self,
+        ])
 
         #if DEBUG
         Hotwire.config.debugLoggingEnabled = true

--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -11,14 +11,6 @@ final class SceneController: UIResponder {
 
     // MARK: - Setup
 
-    private func configureBridge() {
-        Hotwire.registerBridgeComponents([
-            FormComponent.self,
-            MenuComponent.self,
-            OverflowMenuComponent.self,
-        ])
-    }
-
     private func configureRootViewController() {
         guard let window = window else {
             fatalError()
@@ -47,8 +39,6 @@ extension SceneController: UIWindowSceneDelegate {
 
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
-
-        configureBridge()
         configureRootViewController()
 
         navigator.route(rootURL)


### PR DESCRIPTION
This PR moves the `registerBridgeComponents` call from `SceneController` to `AppDelegate` consolidating the global configuration.
