### PR TITLE
Breaking API change: applications can set a User-Agent prefix

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -20,6 +20,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .file(Bundle.main.url(forResource: "path-configuration", withExtension: "json")!)
         ])
 
+        // Set an optional custom user agent application prefix.
+        Hotwire.config.applicationUserAgentPrefix = "Hotwire Demo;"
+
         // Register bridge components
         Hotwire.registerBridgeComponents([
             FormComponent.self,

--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -12,6 +12,10 @@ final class SceneController: UIResponder {
     // MARK: - Setup
 
     private func configureBridge() {
+        // TODO: Move to AppDelegate when PR #55 is merged.
+        // https://github.com/hotwired/hotwire-native-ios/pull/55/files
+        Hotwire.config.applicationUserAgentPrefix = "Hotwire Demo;"
+
         Hotwire.registerBridgeComponents([
             FormComponent.self,
             MenuComponent.self,

--- a/Source/Bridge/UserAgent.swift
+++ b/Source/Bridge/UserAgent.swift
@@ -1,8 +1,15 @@
 import Foundation
 
-public enum UserAgent {
-    public static func userAgentSubstring(for componentTypes: [BridgeComponent.Type]) -> String {
+enum UserAgent {
+    static func build(componentTypes: [BridgeComponent.Type], applicationPrefix: String?) -> String {
         let components = componentTypes.map { $0.name }.joined(separator: " ")
-        return "bridge-components: [\(components)]"
+        let componentsSubstring = "bridge-components: [\(components)]"
+
+        return [
+            applicationPrefix,
+            "Hotwire Native iOS;",
+            "Turbo Native iOS;",
+            componentsSubstring
+        ].compactMap { $0 }.joined(separator: " ")
     }
 }

--- a/Source/Bridge/UserAgent.swift
+++ b/Source/Bridge/UserAgent.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum UserAgent {
-    static func build(componentTypes: [BridgeComponent.Type], applicationPrefix: String?) -> String {
+    static func build(applicationPrefix: String?, componentTypes: [BridgeComponent.Type]) -> String {
         let components = componentTypes.map { $0.name }.joined(separator: " ")
         let componentsSubstring = "bridge-components: [\(components)]"
 

--- a/Source/Hotwire.swift
+++ b/Source/Hotwire.swift
@@ -9,7 +9,6 @@ public enum Hotwire {
     /// Use `Hotwire.config.makeCustomWebView` to customize the web view or web view
     /// configuration further, making sure to call `Bridge.initialize()`.
     public static func registerBridgeComponents(_ componentTypes: [BridgeComponent.Type]) {
-        Hotwire.config.userAgent += " \(UserAgent.userAgentSubstring(for: componentTypes))"
         bridgeComponentTypes = componentTypes
 
         Hotwire.config.makeCustomWebView = { configuration in

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -80,8 +80,8 @@ public struct HotwireConfig {
         let configuration = WKWebViewConfiguration()
         configuration.defaultWebpagePreferences?.preferredContentMode = .mobile
         configuration.applicationNameForUserAgent = UserAgent.build(
-            componentTypes: Hotwire.bridgeComponentTypes,
-            applicationPrefix: applicationUserAgentPrefix
+            applicationPrefix: applicationUserAgentPrefix,
+            componentTypes: Hotwire.bridgeComponentTypes
         )
         configuration.processPool = sharedProcessPool
         return configuration

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -4,10 +4,16 @@ import WebKit
 public struct HotwireConfig {
     public typealias WebViewBlock = (_ configuration: WKWebViewConfiguration) -> WKWebView
 
-    /// Override to set a custom user agent.
-    /// - Important: Include "Hotwire Native" or "Turbo Native" to use `turbo_native_app?`
-    /// on your Rails server.
-    public var userAgent = "Hotwire Native iOS; Turbo Native iOS"
+    /// Set a custom user agent application prefix for every WKWebView instance.
+    ///
+    /// The library will automatically append a substring to your prefix
+    /// which includes:
+    /// - "Hotwire Native iOS; Turbo Native iOS;"
+    /// - "bridge-components: [your bridge components];"
+    ///
+    /// WKWebView's default user agent string will also appear at the
+    /// beginning of the user agent.
+    public var applicationUserAgentPrefix: String? = nil
 
     /// When enabled, adds a `UIBarButtonItem` of type `.done` to the left
     /// navigation bar button item on screens presented modally.
@@ -73,7 +79,10 @@ public struct HotwireConfig {
     private func makeWebViewConfiguration() -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.defaultWebpagePreferences?.preferredContentMode = .mobile
-        configuration.applicationNameForUserAgent = userAgent
+        configuration.applicationNameForUserAgent = UserAgent.build(
+            componentTypes: Hotwire.bridgeComponentTypes,
+            applicationPrefix: applicationUserAgentPrefix
+        )
         configuration.processPool = sharedProcessPool
         return configuration
     }

--- a/Tests/Bridge/UserAgentTests.swift
+++ b/Tests/Bridge/UserAgentTests.swift
@@ -5,24 +5,24 @@ import XCTest
 class UserAgentTests: XCTestCase {
     func testUserAgentSubstringWithNoComponents() {
         let userAgentSubstring = UserAgent.build(
-            componentTypes: [],
-            applicationPrefix: nil
+            applicationPrefix: nil,
+            componentTypes: []
         )
         XCTAssertEqual(userAgentSubstring, "Hotwire Native iOS; Turbo Native iOS; bridge-components: []")
     }
 
     func testUserAgentSubstringWithTwoComponents() {
         let userAgentSubstring = UserAgent.build(
-            componentTypes: [OneBridgeComponent.self, TwoBridgeComponent.self],
-            applicationPrefix: nil
+            applicationPrefix: nil,
+            componentTypes: [OneBridgeComponent.self, TwoBridgeComponent.self]
         )
         XCTAssertEqual(userAgentSubstring, "Hotwire Native iOS; Turbo Native iOS; bridge-components: [one two]")
     }
 
     func testUserAgentSubstringCustomPrefix() {
         let userAgentSubstring = UserAgent.build(
-            componentTypes: [OneBridgeComponent.self, TwoBridgeComponent.self],
-            applicationPrefix: "Hotwire Demo;"
+            applicationPrefix: "Hotwire Demo;",
+            componentTypes: [OneBridgeComponent.self, TwoBridgeComponent.self]
         )
         XCTAssertEqual(userAgentSubstring, "Hotwire Demo; Hotwire Native iOS; Turbo Native iOS; bridge-components: [one two]")
     }

--- a/Tests/Bridge/UserAgentTests.swift
+++ b/Tests/Bridge/UserAgentTests.swift
@@ -1,15 +1,29 @@
 import Foundation
-import HotwireNative
+@testable import HotwireNative
 import XCTest
 
 class UserAgentTests: XCTestCase {
-    func testUserAgentSubstringWithTwoComponents() {
-        let userAgentSubstring = UserAgent.userAgentSubstring(for: [OneBridgeComponent.self, TwoBridgeComponent.self])
-        XCTAssertEqual(userAgentSubstring, "bridge-components: [one two]")
+    func testUserAgentSubstringWithNoComponents() {
+        let userAgentSubstring = UserAgent.build(
+            componentTypes: [],
+            applicationPrefix: nil
+        )
+        XCTAssertEqual(userAgentSubstring, "Hotwire Native iOS; Turbo Native iOS; bridge-components: []")
     }
 
-    func testUserAgentSubstringWithNoComponents() {
-        let userAgentSubstring = UserAgent.userAgentSubstring(for: [])
-        XCTAssertEqual(userAgentSubstring, "bridge-components: []")
+    func testUserAgentSubstringWithTwoComponents() {
+        let userAgentSubstring = UserAgent.build(
+            componentTypes: [OneBridgeComponent.self, TwoBridgeComponent.self],
+            applicationPrefix: nil
+        )
+        XCTAssertEqual(userAgentSubstring, "Hotwire Native iOS; Turbo Native iOS; bridge-components: [one two]")
+    }
+
+    func testUserAgentSubstringCustomPrefix() {
+        let userAgentSubstring = UserAgent.build(
+            componentTypes: [OneBridgeComponent.self, TwoBridgeComponent.self],
+            applicationPrefix: "Hotwire Demo;"
+        )
+        XCTAssertEqual(userAgentSubstring, "Hotwire Demo; Hotwire Native iOS; Turbo Native iOS; bridge-components: [one two]")
     }
 }


### PR DESCRIPTION
Brings [Android PR #77](https://github.com/hotwired/hotwire-native-android/pull/77) to iOS, allowing developers to set a custom user agent *prefix* without breaking bridge components or removing "Hotwire Native".

Developers can set a custom `applicationUserAgentPrefix` for their application via:
```swift
Hotwire.config.applicationUserAgentPrefix = "My Application Prefix;"
```

Whenever a `WKWebView` instance is created, the library will now automatically include:
- Your (optional) custom `applicationUserAgentPrefix`
- "Hotwire Native iOS; Turbo Native iOS;"
- "bridge-components: [your bridge components];"

`WKWebView`'s default user agent will also be added to the beginning of the user agent.