### PR TITLE
Document makeCustomWebView w/ bridge components

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -42,7 +42,19 @@ public struct HotwireConfig {
     }
 
     /// Optionally customize the web views used by each Turbo Session.
+    ///
     /// Ensure you return a new instance each time.
+    /// Make sure to call `Bridge.initialize(webView)` if you are using bridge
+    /// components and call this *after* `Hotwire.registerBridgeComponents()`.
+    ///
+    /// ```swift
+    /// Hotwire.config.makeCustomWebView = { config in
+    ///     let webView = WKWebView(frame: .zero, configuration: config)
+    ///     Bridge.initialize(webView)
+    ///     // Customize web view...
+    ///     return webView
+    /// }
+    /// ```
     public var makeCustomWebView: WebViewBlock = { (configuration: WKWebViewConfiguration) in
         WKWebView.debugInspectable(configuration: configuration)
     }


### PR DESCRIPTION
As discussed in #57:

> Using both `Hotwire.config.makeCustomWebView` and `Hotwire.registerBridgeComponents()` causes unexpected behavior. If the web view is configured first then it is not used. If bridge components are registered first then the bridge is not initialized in the web view.

This PR documents that a developer must manually call `Bridge.initialize(webView)` if using `Hotwire.config.makeCustomWebView` *and* call it after calling `Hotwire.registerBridgeComponents()`. It's not ideal, but I'm not sure of a better fix just yet.

But we do have some nice option-click documentation now!

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/161cb26e-8684-4b34-b07c-b9bb13436dc8" />
