### PR TITLE
Disable link prefetching via the turbo js adapter to prevent double-visit requests

### DIFF
--- a/Source/Turbo/WebView/turbo.js
+++ b/Source/Turbo/WebView/turbo.js
@@ -169,6 +169,12 @@
       this.postMessage("pageInvalidated")
     }
 
+    linkPrefetchingIsEnabledForLocation(location) {
+      // Disable link prefetching since it can be activated by link taps and
+      // cause double-requests across the default/modal context boundaries.
+      return false
+    }
+
     log(message) {
       this.postMessage("log", { message: message })
     }

--- a/Source/Turbo/WebView/turbo.js
+++ b/Source/Turbo/WebView/turbo.js
@@ -171,7 +171,8 @@
 
     linkPrefetchingIsEnabledForLocation(location) {
       // Disable link prefetching since it can be activated by link taps and
-      // cause double-requests across the default/modal context boundaries.
+      // cause double-requests across the default/modal context boundaries. We
+      // also don't want to prefetch links that may correspond to native screens.
       return false
     }
 


### PR DESCRIPTION
This addresses the double-visit request issue found in #12. It works with the new adapter function in core `turbo.js` added here: https://github.com/hotwired/turbo/pull/1354

The root issue is that link taps on iOS are triggering the `mouseenter` and `mouseleave` events used to activate link prefetching. This theoretical optimization actually creates wasteful `GET` requests across the `default` and `modal` context `WKWebView` instances.