### PR TITLE
add public method to allow clearing the turbo session cache

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -87,6 +87,11 @@ public class Navigator {
         modalSession.reload()
     }
 
+    /// Invalidates the session cache.
+    public func invalidateSessionCache() {
+        session.markSnapshotCacheAsStale()
+    }
+
     /// Navigate to an external URL.
     ///
     /// - Parameters:


### PR DESCRIPTION
I'm encountering an issue with my `UITabBarController`-based app related to navigation state and Turbo session cache behavior.

#### Scenario

- **Tab A** Navigation Stack:
  1. `/posts` (index page)
  2. `/posts/1` (show page)

- **Tab B** Navigation Stack:
  1. `/posts` (index page)
  2. `/posts/1` (show page)
  3. `/posts/1/edit` (edit page, where a POST request is made)
  4. Back to `/posts/1` (show page)  
     - The Turbo session cache is **busted**, and the back button now shows updated data on the index page.

#### Issue

After interacting with Tab B and returning to Tab A:

1. Tab A’s `/posts/1` (show page) is updated as expected because the navigator executed a `Turbo.visit(page.url, {action: 'replace'})`.
2. However, when pressing the back button in Tab A:
   - The `/posts` (index page) is **stale** because the Turbo session cache for Tab A’s navigator was **not busted**.

Having a way to clear the cache manually would fix my issue.