### PR TITLE
server driven navigation without path configuration

### DIFF
--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -2,6 +2,32 @@ import SafariServices
 import UIKit
 import WebKit
 
+extension NavigationHierarchyController {
+    /// Handles special Turbo historical location routes
+       private func handleHistoricalLocation(proposal: VisitProposal) {
+           switch proposal.url.path {
+           case "/recede_historical_location":
+               // Pop or dismiss the current view
+               pop(animated: proposal.animated)
+
+           case "/resume_historical_location":
+               // No-op - do nothing
+               break
+               
+           case "/refresh_historical_location":
+               // refresh current view
+               refresh(via: proposal)
+           default:
+               break
+           }
+       }
+       
+       /// Check if URL is a Turbo historical location directive
+       private func isHistoricalLocation(_ url: URL) -> Bool {
+           return url.path.hasSuffix("_historical_location")
+       }
+}
+
 class NavigationHierarchyController {
     let navigationController: UINavigationController
     let modalNavigationController: UINavigationController
@@ -34,6 +60,11 @@ class NavigationHierarchyController {
     }
 
     func route(controller: UIViewController, proposal: VisitProposal) {
+        if isHistoricalLocation(proposal.url) {
+            handleHistoricalLocation(proposal: proposal)
+              return
+        }
+        
         if let alert = controller as? UIAlertController {
             presentAlert(alert, via: proposal)
         } else {


### PR DESCRIPTION
This PR addresses [Issue #71](https://github.com/hotwired/hotwire-native-ios/issues/71), which proposed adding support for server-driven routes like `/recede_historical_location`, `/resume_historical_location`, and `/refresh_historical_location`. These routes are designed to handle navigation stack behaviors (pop, refresh, or no-op) based on directives from the server.

## Implementation Overview
I've introduced a new extension to the NavigationHierarchyController class to handle these historical location routes. Key changes include:

### Route Handling:

- Added a handleHistoricalLocation(proposal:) method to process specific historical routes and execute actions such as:
  - `recede_historical_location`: Pops the current view or dismisses a modal.
  - `resume_historical_location`: No-op (does nothing).
  - `refresh_historical_location`: Refreshes the current view via a VisitProposal.

### Route Detection:

Added an `isHistoricalLocation(_:)` helper method to determine if a given URL matches one of the `_historical_location` patterns.
### Routing Logic:

Updated `route(controller:proposal:)` to check for historical location routes before falling back to default routing logic.

## Goals of This PR

- **Start the Discussion:** This is a proof of concept, and I’d like to gather feedback on whether this is the right direction for implementation.
- **Evaluate the Approach:** Does adding this logic to NavigationHierarchyController align with the desired architecture? Is there a better way to integrate this functionality natively without requiring explicit path configurations?
- **Explore Next Steps:** If this approach works, we could look into automating or simplifying the configuration process.

### Notes: 
I will be adding tests in the coming days - just wanted to see what the initial reaction might be. 