### PR TITLE
Include default server route rules by default

### DIFF
--- a/Source/Turbo/Navigator/Extensions/PathPropertiesExtensions.swift
+++ b/Source/Turbo/Navigator/Extensions/PathPropertiesExtensions.swift
@@ -72,4 +72,8 @@ public extension PathProperties {
     var animated: Bool {
         self["animated"] as? Bool ?? true
     }
+
+    internal var historicalLocation: Bool {
+        self["historical_location"] as? Bool ?? false
+    }
 }

--- a/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
@@ -28,4 +28,8 @@ public extension VisitProposal {
     var animated: Bool {
         properties.animated
     }
+
+    internal var isHistoricalLocation: Bool {
+        properties.historicalLocation
+    }
 }

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -63,7 +63,7 @@ class NavigationHierarchyController {
     }
 
     func pop(animated: Bool) {
-        if navigationController.presentedViewController != nil {
+        if navigationController.presentedViewController != nil && !modalNavigationController.isBeingDismissed {
             if modalNavigationController.viewControllers.count == 1 {
                 navigationController.dismiss(animated: animated)
             } else {

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -2,6 +2,32 @@ import SafariServices
 import UIKit
 import WebKit
 
+extension NavigationHierarchyController {
+    /// Handles special Turbo historical location routes
+       private func handleHistoricalLocation(proposal: VisitProposal) {
+           switch proposal.url.path {
+           case "/recede_historical_location":
+               // Pop or dismiss the current view
+               pop(animated: proposal.animated)
+
+           case "/resume_historical_location":
+               // No-op - do nothing
+               break
+               
+           case "/refresh_historical_location":
+               // refresh current view
+               refresh(via: proposal)
+           default:
+               break
+           }
+       }
+       
+       /// Check if URL is a Turbo historical location directive
+       private func isHistoricalLocation(_ url: URL) -> Bool {
+           return url.path.hasSuffix("_historical_location")
+       }
+}
+
 class NavigationHierarchyController {
     let navigationController: UINavigationController
     let modalNavigationController: UINavigationController
@@ -34,6 +60,11 @@ class NavigationHierarchyController {
     }
 
     func route(controller: UIViewController, proposal: VisitProposal) {
+        if isHistoricalLocation(proposal.url) {
+            handleHistoricalLocation(proposal: proposal)
+              return
+        }
+        
         if let alert = controller as? UIAlertController {
             presentAlert(alert, via: proposal)
         } else {

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -2,32 +2,6 @@ import SafariServices
 import UIKit
 import WebKit
 
-extension NavigationHierarchyController {
-    /// Handles special Turbo historical location routes
-       private func handleHistoricalLocation(proposal: VisitProposal) {
-           switch proposal.url.path {
-           case "/recede_historical_location":
-               // Pop or dismiss the current view
-               pop(animated: proposal.animated)
-
-           case "/resume_historical_location":
-               // No-op - do nothing
-               break
-               
-           case "/refresh_historical_location":
-               // refresh current view
-               refresh(via: proposal)
-           default:
-               break
-           }
-       }
-       
-       /// Check if URL is a Turbo historical location directive
-       private func isHistoricalLocation(_ url: URL) -> Bool {
-           return url.path.hasSuffix("_historical_location")
-       }
-}
-
 class NavigationHierarchyController {
     let navigationController: UINavigationController
     let modalNavigationController: UINavigationController
@@ -60,11 +34,6 @@ class NavigationHierarchyController {
     }
 
     func route(controller: UIViewController, proposal: VisitProposal) {
-        if isHistoricalLocation(proposal.url) {
-            handleHistoricalLocation(proposal: proposal)
-              return
-        }
-        
         if let alert = controller as? UIAlertController {
             presentAlert(alert, via: proposal)
         } else {

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -216,10 +216,8 @@ class NavigationHierarchyController {
     private func dismissModalIfNeeded(for visit: VisitProposal) {
         // The desired behaviour for historical location visits is
         // to always dismiss the "modal" stack.
-        guard visit.isHistoricalLocation,
-              navigationController.presentedViewController != nil else {
-            return
-        }
+        let dismissModal = visit.isHistoricalLocation && navigationController.presentedViewController != nil
+        guard dismissModal else { return }
 
         navigationController.dismiss(animated: visit.animated)
     }

--- a/Source/Turbo/Path Configuration/PathConfiguration.swift
+++ b/Source/Turbo/Path Configuration/PathConfiguration.swift
@@ -28,7 +28,8 @@ public final class PathConfiguration {
     public private(set) var settings: [String: AnyHashable] = [:]
 
     /// The list of rules from the configuration: `{ rules: [] }`
-    public private(set) var rules: [PathRule] = []
+    /// Default server route rules are included by default.
+    public private(set) var rules: [PathRule] = PathRule.defaultServerRoutes
 
     /// Sources for this configuration, setting it will
     /// cause the configuration to be loaded from the new sources
@@ -93,6 +94,8 @@ public final class PathConfiguration {
         // Update our internal state with the config from the loader
         settings = config.settings
         rules = config.rules
+        // Always include the default server route rules.
+        rules.append(contentsOf: PathRule.defaultServerRoutes)
         delegate?.pathConfigurationDidUpdate()
     }
 }

--- a/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
+++ b/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
@@ -11,7 +11,6 @@ extension PathRule {
         patterns: ["/recede_historical_location"],
         properties: [
             "presentation": "pop",
-            "visitable": false,
             "historical_location": true
         ]
     )
@@ -20,7 +19,6 @@ extension PathRule {
         patterns: ["/resume_historical_location"],
         properties: [
             "presentation": "none",
-            "visitable": false,
             "historical_location": true
         ]
     )
@@ -29,7 +27,6 @@ extension PathRule {
         patterns: ["/refresh_historical_location"],
         properties: [
             "presentation": "refresh",
-            "visitable": false,
             "historical_location": true
         ]
     )

--- a/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
+++ b/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
@@ -11,6 +11,7 @@ extension PathRule {
         patterns: ["/recede_historical_location"],
         properties: [
             "presentation": "pop",
+            "context": "default",
             "historical_location": true
         ]
     )
@@ -19,6 +20,7 @@ extension PathRule {
         patterns: ["/resume_historical_location"],
         properties: [
             "presentation": "none",
+            "context": "default",
             "historical_location": true
         ]
     )
@@ -27,6 +29,7 @@ extension PathRule {
         patterns: ["/refresh_historical_location"],
         properties: [
             "presentation": "refresh",
+            "context": "default",
             "historical_location": true
         ]
     )

--- a/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
+++ b/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension PathRule {
+    static let defaultServerRoutes: [PathRule] = [
+        .recedeHistoricalLocation,
+        .resumeHistoricalLocation,
+        .refreshHistoricalLocation
+    ]
+
+    static let recedeHistoricalLocation = PathRule(
+        patterns: ["/recede_historical_location"],
+        properties: [
+            "presentation": "pop",
+            "visitable": false
+        ]
+    )
+
+    static let resumeHistoricalLocation = PathRule(
+        patterns: ["/resume_historical_location"],
+        properties: [
+            "presentation": "none",
+            "visitable": false
+        ]
+    )
+
+    static let refreshHistoricalLocation = PathRule(
+        patterns: ["/refresh_historical_location"],
+        properties: [
+            "presentation": "refresh",
+            "visitable": false
+        ]
+    )
+}

--- a/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
+++ b/Source/Turbo/Path Configuration/PathRule+ServerRoutes.swift
@@ -11,7 +11,8 @@ extension PathRule {
         patterns: ["/recede_historical_location"],
         properties: [
             "presentation": "pop",
-            "visitable": false
+            "visitable": false,
+            "historical_location": true
         ]
     )
 
@@ -19,7 +20,8 @@ extension PathRule {
         patterns: ["/resume_historical_location"],
         properties: [
             "presentation": "none",
-            "visitable": false
+            "visitable": false,
+            "historical_location": true
         ]
     )
 
@@ -27,7 +29,8 @@ extension PathRule {
         patterns: ["/refresh_historical_location"],
         properties: [
             "presentation": "refresh",
-            "visitable": false
+            "visitable": false,
+            "historical_location": true
         ]
     )
 }

--- a/Tests/Turbo/Fixtures/test-configuration-historical-locations.json
+++ b/Tests/Turbo/Fixtures/test-configuration-historical-locations.json
@@ -1,0 +1,31 @@
+{
+  "rules":[
+    {
+      "patterns":[
+        "/recede_historical_location"
+      ],
+      "properties":{
+        "presentation":"pop",
+        "context":"modal"
+      }
+    },
+    {
+      "patterns":[
+        "/resume_historical_location"
+      ],
+      "properties":{
+        "presentation":"refresh",
+        "context":"modal"
+      }
+    },
+    {
+      "patterns":[
+        "/refresh_historical_location"
+      ],
+      "properties":{
+        "presentation":"pop",
+        "context":"modal"
+      }
+    }
+  ]
+}

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerHistoricalLocationTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerHistoricalLocationTests.swift
@@ -24,18 +24,15 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
     func test_resumeHistoricalLocation() async throws {
         let defaultOne = VisitProposal(path: "/default_one", context: .default)
         navigator.route(defaultOne)
-        try await delay()
 
         let defaultTwo = VisitProposal(path: "/default_two", context: .default)
         navigator.route(defaultTwo)
-        try await delay()
 
         XCTAssertEqual(navigationController.viewControllers.count, 2)
 
         let modalOne = VisitProposal(path: "/modal_one", context: .modal)
         navigator.route(modalOne)
 
-        try await delay()
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
 
         // Reset spy's properties.
@@ -47,7 +44,6 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
             additionalProperties: PathRule.resumeHistoricalLocation.properties
         )
         navigator.route(resumeHistoricalLocationProposal)
-        try await delay()
 
         XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
@@ -62,13 +58,11 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
     func test_refreshHistoricalLocation() async throws {
         let defaultOne = VisitProposal(path: "/default_one", context: .default)
         navigator.route(defaultOne)
-        try await delay()
 
         XCTAssertEqual(navigationController.viewControllers.count, 1)
 
         let modalOne = VisitProposal(path: "/modal_one", context: .modal)
         navigator.route(modalOne)
-        try await delay()
 
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
 
@@ -81,7 +75,6 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
             additionalProperties: PathRule.refreshHistoricalLocation.properties
         )
         navigator.route(refreshHistoricalLocationProposal)
-        try await delay()
 
         XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
@@ -99,17 +92,14 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
     func test_recedeHistoricalLocation() async throws {
         let defaultOne = VisitProposal(path: "/default_one", context: .default)
         navigator.route(defaultOne)
-        try await delay()
 
         let defaultTwo = VisitProposal(path: "/default_two", context: .default)
         navigator.route(defaultTwo)
-        try await delay()
 
         XCTAssertEqual(navigationController.viewControllers.count, 2)
 
         let modalOne = VisitProposal(path: "/modal_one", context: .modal)
         navigator.route(modalOne)
-        try await delay()
 
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
 
@@ -118,15 +108,9 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
             additionalProperties: PathRule.recedeHistoricalLocation.properties
         )
         navigator.route(recedeHistoricalLocationProposal)
-        try await delay()
 
         XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
-        XCTAssertEqual(navigator.session.activeVisitable?.visitableURL, defaultOne.url)
-    }
-
-    func delay() async throws {
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
     }
 
     private let session = SessionSpy(webView: Hotwire.config.makeWebView())

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerHistoricalLocationTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerHistoricalLocationTests.swift
@@ -1,0 +1,148 @@
+@testable import HotwireNative
+import XCTest
+
+@MainActor
+final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
+    override func setUp() {
+        navigationController = TestableNavigationController()
+        modalNavigationController = TestableNavigationController()
+
+        navigator = Navigator(session: session, modalSession: modalSession)
+        hierarchyController = NavigationHierarchyController(
+            delegate: navigator,
+            navigationController: navigationController,
+            modalNavigationController: modalNavigationController
+        )
+        navigator.hierarchyController = hierarchyController
+
+        loadNavigationControllerInWindow()
+    }
+
+    // Resume behaviour:
+    // 1. Dismiss the modal view controller.
+    // 2. Arrive back at the view controller on the "default" stack.
+    func test_resumeHistoricalLocation() async throws {
+        let defaultOne = VisitProposal(path: "/default_one", context: .default)
+        navigator.route(defaultOne)
+        try await delay()
+
+        let defaultTwo = VisitProposal(path: "/default_two", context: .default)
+        navigator.route(defaultTwo)
+        try await delay()
+
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+
+        let modalOne = VisitProposal(path: "/modal_one", context: .modal)
+        navigator.route(modalOne)
+
+        try await delay()
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
+
+        // Reset spy's properties.
+        session.visitWasCalled = false
+        session.visitAction = nil
+
+        let resumeHistoricalLocationProposal = VisitProposal(
+            path: PathRule.resumeHistoricalLocation.patterns.first!,
+            additionalProperties: PathRule.resumeHistoricalLocation.properties
+        )
+        navigator.route(resumeHistoricalLocationProposal)
+        try await delay()
+
+        XCTAssertNil(navigationController.presentedViewController)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertEqual(navigator.session.activeVisitable?.visitableURL, defaultTwo.url)
+        XCTAssertFalse(session.visitWasCalled)
+    }
+
+    // Refresh behaviour:
+    // 1. Dismiss the modal view controller.
+    // 2. Arrive back at the view controller on the "default" stack.
+    // 3. Refresh the view controller on the "default" stack by revisiting the location.
+    func test_refreshHistoricalLocation() async throws {
+        let defaultOne = VisitProposal(path: "/default_one", context: .default)
+        navigator.route(defaultOne)
+        try await delay()
+
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+
+        let modalOne = VisitProposal(path: "/modal_one", context: .modal)
+        navigator.route(modalOne)
+        try await delay()
+
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
+
+        // Reset spy's properties.
+        session.visitWasCalled = false
+        session.visitAction = nil
+
+        let refreshHistoricalLocationProposal = VisitProposal(
+            path: PathRule.refreshHistoricalLocation.patterns.first!,
+            additionalProperties: PathRule.refreshHistoricalLocation.properties
+        )
+        navigator.route(refreshHistoricalLocationProposal)
+        try await delay()
+
+        XCTAssertNil(navigationController.presentedViewController)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertEqual(navigator.session.activeVisitable?.visitableURL, defaultOne.url)
+        XCTAssertTrue(session.visitWasCalled)
+        XCTAssertEqual(session.visitAction, .restore)
+    }
+
+    // Recede behaviour:
+    // 1. Dismiss the modal view controller.
+    // 2. Arrive back at the view controller on the "default" stack.
+    // 3. Pop the view controller on the "default" stack (unless it's already at the beginning of the backstack).
+    // 4. This will trigger a refresh on the appeared view controller if the snapshot cache has been cleared by a form submission.
+    @MainActor
+    func test_recedeHistoricalLocation() async throws {
+        let defaultOne = VisitProposal(path: "/default_one", context: .default)
+        navigator.route(defaultOne)
+        try await delay()
+
+        let defaultTwo = VisitProposal(path: "/default_two", context: .default)
+        navigator.route(defaultTwo)
+        try await delay()
+
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+
+        let modalOne = VisitProposal(path: "/modal_one", context: .modal)
+        navigator.route(modalOne)
+        try await delay()
+
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
+
+        let recedeHistoricalLocationProposal = VisitProposal(
+            path: PathRule.recedeHistoricalLocation.patterns.first!,
+            additionalProperties: PathRule.recedeHistoricalLocation.properties
+        )
+        navigator.route(recedeHistoricalLocationProposal)
+        try await delay()
+
+        XCTAssertNil(navigationController.presentedViewController)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertEqual(navigator.session.activeVisitable?.visitableURL, defaultOne.url)
+    }
+
+    func delay() async throws {
+        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+    }
+
+    private let session = SessionSpy(webView: Hotwire.config.makeWebView())
+    private let modalSession = Session(webView: Hotwire.config.makeWebView())
+
+    private var navigator: Navigator!
+    private var hierarchyController: NavigationHierarchyController!
+    private var navigationController: TestableNavigationController!
+    private var modalNavigationController: TestableNavigationController!
+
+    private let window = UIWindow()
+
+    // Simulate a "real" app so presenting view controllers works under test.
+    private func loadNavigationControllerInWindow() {
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        navigationController.loadViewIfNeeded()
+    }
+}

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -429,7 +429,7 @@ private class EmptyNavigationDelegate: NavigationHierarchyControllerDelegate {
 
 // MARK: - VisitProposal extension
 
-private extension VisitProposal {
+extension VisitProposal {
     init(path: String = "",
          action: VisitAction = .advance,
          context: Navigation.Context = .default,
@@ -441,7 +441,7 @@ private extension VisitProposal {
             "context": context.rawValue,
             "presentation": presentation.rawValue
         ]
-        let properties = defaultProperties.merging(additionalProperties) { (current, _) in current }
+        let properties = defaultProperties.merging(additionalProperties) { (_, new) in new }
 
         self.init(url: url, options: options, properties: properties)
     }

--- a/Tests/Turbo/Navigator/TestableNavigationController.swift
+++ b/Tests/Turbo/Navigator/TestableNavigationController.swift
@@ -1,9 +1,10 @@
 import UIKit
+@testable import HotwireNative
 
 /// Manipulate a navigation controller under test.
 /// Ensures `viewControllers` is updated synchronously.
 /// Manages `presentedViewController` directly because it isn't updated on the same thread.
-class TestableNavigationController: UINavigationController {
+class TestableNavigationController: HotwireNavigationController {
     override var presentedViewController: UIViewController? {
         get { _presentedViewController }
         set { _presentedViewController = newValue }

--- a/Tests/Turbo/PathConfigurationTests.swift
+++ b/Tests/Turbo/PathConfigurationTests.swift
@@ -30,6 +30,28 @@ class PathConfigurationTests: XCTestCase {
         }
     }
 
+    func test_loadingPathConfigWithHistoricalLocationRulesDoesNotOverrideTheDefaults() {
+        let fileURL = Bundle.module.url(
+            forResource: "test-configuration-historical-locations",
+            withExtension: "json",
+            subdirectory: "Fixtures")!
+        configuration.sources = [.file(fileURL)]
+
+        XCTAssertEqual(configuration.rules.count, 3 + PathRule.defaultServerRoutes.count)
+
+        let recedeProperties = configuration.properties(for: "/recede_historical_location")
+        XCTAssertEqual(recedeProperties.context, .default)
+        XCTAssertEqual(recedeProperties.presentation, .pop)
+
+        let refreshProperties = configuration.properties(for: "/refresh_historical_location")
+        XCTAssertEqual(refreshProperties.context, .default)
+        XCTAssertEqual(refreshProperties.presentation, .refresh)
+
+        let resumeProperties = configuration.properties(for: "/resume_historical_location")
+        XCTAssertEqual(resumeProperties.context, .default)
+        XCTAssertEqual(resumeProperties.presentation, .none)
+    }
+
     func test_settings_returnsCurrentSettings() {
         loadConfigurationFromFile()
 

--- a/Tests/Turbo/PathRuleTests.swift
+++ b/Tests/Turbo/PathRuleTests.swift
@@ -27,4 +27,41 @@ class PathRuleTests: XCTestCase {
         XCTAssertFalse(rule.match(path: "/new"))
         XCTAssertFalse(rule.match(path: "foo"))
     }
+
+    func test_recedeHistoricalLocation() {
+        let rule = PathRule.recedeHistoricalLocation
+        XCTAssertEqual(rule.patterns, ["/recede_historical_location"])
+        XCTAssertEqual(rule.properties, ["presentation": "pop",
+                                         "visitable": false,
+                                         "historical_location": true])
+    }
+
+    func test_refreshHistoricalLocation() {
+        let rule = PathRule.refreshHistoricalLocation
+        XCTAssertEqual(rule.patterns, ["/refresh_historical_location"])
+        XCTAssertEqual(rule.properties, ["presentation": "refresh",
+                                         "visitable": false,
+                                         "historical_location": true])
+    }
+
+    func test_resumeHistoricalLocation() {
+        let rule = PathRule.resumeHistoricalLocation
+        XCTAssertEqual(rule.patterns, ["/resume_historical_location"])
+        XCTAssertEqual(rule.properties, ["presentation": "none",
+                                         "visitable": false,
+                                         "historical_location": true])
+    }
+
+    func test_defaultHistoricalLocationRules() {
+        XCTAssertEqual(PathRule.defaultServerRoutes.count, 3)
+        let expectedRules: [PathRule] = [
+            PathRule.recedeHistoricalLocation,
+            PathRule.resumeHistoricalLocation,
+            PathRule.refreshHistoricalLocation
+        ]
+
+        if #available(iOS 16.0, *) {
+            XCTAssertTrue(PathRule.defaultServerRoutes.contains(expectedRules))
+        }
+    }
 }

--- a/Tests/Turbo/PathRuleTests.swift
+++ b/Tests/Turbo/PathRuleTests.swift
@@ -32,7 +32,6 @@ class PathRuleTests: XCTestCase {
         let rule = PathRule.recedeHistoricalLocation
         XCTAssertEqual(rule.patterns, ["/recede_historical_location"])
         XCTAssertEqual(rule.properties, ["presentation": "pop",
-                                         "visitable": false,
                                          "historical_location": true])
     }
 
@@ -40,7 +39,6 @@ class PathRuleTests: XCTestCase {
         let rule = PathRule.refreshHistoricalLocation
         XCTAssertEqual(rule.patterns, ["/refresh_historical_location"])
         XCTAssertEqual(rule.properties, ["presentation": "refresh",
-                                         "visitable": false,
                                          "historical_location": true])
     }
 
@@ -48,7 +46,6 @@ class PathRuleTests: XCTestCase {
         let rule = PathRule.resumeHistoricalLocation
         XCTAssertEqual(rule.patterns, ["/resume_historical_location"])
         XCTAssertEqual(rule.properties, ["presentation": "none",
-                                         "visitable": false,
                                          "historical_location": true])
     }
 

--- a/Tests/Turbo/PathRuleTests.swift
+++ b/Tests/Turbo/PathRuleTests.swift
@@ -32,6 +32,7 @@ class PathRuleTests: XCTestCase {
         let rule = PathRule.recedeHistoricalLocation
         XCTAssertEqual(rule.patterns, ["/recede_historical_location"])
         XCTAssertEqual(rule.properties, ["presentation": "pop",
+                                         "context": "default",
                                          "historical_location": true])
     }
 
@@ -39,6 +40,7 @@ class PathRuleTests: XCTestCase {
         let rule = PathRule.refreshHistoricalLocation
         XCTAssertEqual(rule.patterns, ["/refresh_historical_location"])
         XCTAssertEqual(rule.properties, ["presentation": "refresh",
+                                         "context": "default",
                                          "historical_location": true])
     }
 
@@ -46,6 +48,7 @@ class PathRuleTests: XCTestCase {
         let rule = PathRule.resumeHistoricalLocation
         XCTAssertEqual(rule.patterns, ["/resume_historical_location"])
         XCTAssertEqual(rule.properties, ["presentation": "none",
+                                         "context": "default",
                                          "historical_location": true])
     }
 

--- a/Tests/Turbo/Spies/SessionSpy.swift
+++ b/Tests/Turbo/Spies/SessionSpy.swift
@@ -1,0 +1,12 @@
+@testable import HotwireNative
+
+final class SessionSpy: Session {
+    var visitWasCalled = false
+    var visitAction: VisitAction?
+
+    override func visit(_ visitable: any Visitable, action: VisitAction) {
+        visitWasCalled = true
+        visitAction = action
+        super.visit(visitable, action: action)
+    }
+}


### PR DESCRIPTION
This PR builds on top of https://github.com/hotwired/hotwire-native-ios/pull/74 and addresses https://github.com/hotwired/hotwire-native-ios/issues/71.

### Context
[Turbo Native](https://native.hotwired.dev/reference/navigation#server-driven-routing-in-rails) allows server-driven routing in Rails applications. Previously, developers had to explicitly define these routing rules in the path config. This PR adds default routing rules for server-driven navigation directly into the framework.

### Changes
- recede, resume and refresh historical location rules (historical location rules) have been added as `PathRule`s.
- historical location rules are now loaded by default whether or not the source of the path config is provided.
- the `NavigationHierarchyController` has been adapted to handle the historical location rules.

### Historical Location Behaviour

**resume_historical_location**
1. Dismiss the modal view controller.
2. Arrive back at the view controller on the "default" stack.

**refresh_historical_location**
1. Dismiss the modal view controller.
2. Arrive back at the view controller on the "default" stack.
3. Refresh the view controller no the "default" stack by revisiting the location.

**recede_historical_location**
1. Dismiss the modal view controller.
2. Arrive back at the view controller on the "default" stack.
3. Pop the view controller on the "default" stack (unless it's already at the beginning of the backstack).
4. This will trigger a refresh on the appeared view controller if the snapshot cache has been cleared by a form submission.