### PR TITLE
Update the `visitableURL` on reload

### DIFF
--- a/Source/Turbo/Session/Session.swift
+++ b/Source/Turbo/Session/Session.swift
@@ -85,7 +85,10 @@ public class Session: NSObject {
 
     public func reload() {
         guard let visitable = topmostVisitable else { return }
-
+        if let currentURL = webView.url {
+            visitable.visitableURL = currentURL
+        }
+        
         initialized = false
         visit(visitable)
         topmostVisit = currentVisit

--- a/Source/Turbo/Visitable/Visitable.swift
+++ b/Source/Turbo/Visitable/Visitable.swift
@@ -14,7 +14,7 @@ public protocol Visitable: AnyObject {
     var visitableViewController: UIViewController { get }
     var visitableDelegate: VisitableDelegate? { get set }
     var visitableView: VisitableView! { get }
-    var visitableURL: URL! { get }
+    var visitableURL: URL! { get set }
 
     func visitableDidRender()
     func showVisitableActivityIndicator()


### PR DESCRIPTION
Hi there,

Sorry for the spam lately 😅
While working on a feature I've noticed that Hotwire Native iOS handles the pull to refresh feature slightly different than Android.   

We use HTML tabs on some views and a bit of JavaScript to update the URL whenever a user switches tabs.   
This ensures that when the page is refreshed, the correct tab is selected.
The JavaScript code looks something like this:
```javascript
tab.addEventListener('click', () => {
  const currentURL = new URL(window.location);
  currentURL.searchParams.set('view_part', tab.dataset.bsTarget)
  window.history.replaceState(history.state, "", currentURL)
})
```

Here's the current behavior:

**Android**

https://github.com/user-attachments/assets/06a28fec-4c1c-4dd8-a13e-3dd4c1382563

**iOS**

https://github.com/user-attachments/assets/bff09688-ae4d-4146-a5a3-8c8df64df763

---

On iOS, when a refresh is triggered, it reloads the (visitable)URL that was set at the start of the ViewController.
This PR updates iOS to behave like Android by ensuring it reloads the current URL from the webview instead.   