### PR TITLE
add `userAgentWithWebViewDefault`on iOS

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -45,6 +45,20 @@ public struct HotwireConfig {
             )
         }
     }
+    
+    /// Gets the full user agent that is used for every WKWebView instance. This includes:
+    /// - The WKWebView's default WebKit user agent string
+    /// - Your (optional) custom `applicationUserAgentPrefix`
+    /// - "Hotwire Native iOS; Turbo Native iOS;"
+    /// - "bridge-components: [your bridge components];"
+    public var userAgentWithWebViewDefault: String {
+        get {
+            if let defaultAgent = Self.cachedUserAgent {
+                return "\(defaultAgent)"
+            }
+            return userAgent
+        }
+    }
 
     // MARK: Turbo
 
@@ -90,10 +104,16 @@ public struct HotwireConfig {
             Bridge.initialize(webView)
         }
         
+        if Self.cachedUserAgent == nil {
+            Self.cachedUserAgent = webView.value(forKey: "userAgent") as? String
+        }
+        
         return webView
     }
 
     // MARK: - Private
+    
+    internal static var cachedUserAgent: String?
 
     private let sharedProcessPool = WKProcessPool()
 

--- a/Tests/Turbo/HotwireConfigTests.swift
+++ b/Tests/Turbo/HotwireConfigTests.swift
@@ -1,7 +1,21 @@
 import XCTest
+import WebKit
 @testable import HotwireNative
 
 final class HotwireConfigTests: XCTestCase {
+    private let sharedProcessPool = WKProcessPool()
+
+    override func setUp() {
+        super.setUp()
+        Hotwire.bridgeComponentTypes.removeAll()
+    }
+    
+    override func tearDown() {
+        Hotwire.bridgeComponentTypes.removeAll()
+        HotwireConfig.cachedUserAgent = nil
+        super.tearDown()
+    }
+    
     func testUserAgent() {
         var config = HotwireConfig()
         config.applicationUserAgentPrefix = "TestApp/1.0"
@@ -10,6 +24,28 @@ final class HotwireConfigTests: XCTestCase {
         Hotwire.registerBridgeComponents([testComponent])
         
         XCTAssertEqual(config.userAgent, "TestApp/1.0 Hotwire Native iOS; Turbo Native iOS; bridge-components: [MockComponent]")
+    }
+    
+    func testUserAgentWithWebViewDefault() {
+        
+        var config = HotwireConfig()
+        config.applicationUserAgentPrefix = "TestApp/1.0"
+        
+        let testComponent = MockBridgeComponent.self
+        Hotwire.registerBridgeComponents([testComponent])
+        
+        let _ = config.makeWebView()
+        
+        let baseWebView = WKWebView(frame: .zero, configuration: makeWebViewConfiguration(userAgent: config.userAgent))
+        let expectedUA = baseWebView.value(forKey: "userAgent") as? String
+        
+        XCTAssertEqual(config.userAgentWithWebViewDefault, expectedUA)
+    }
+    
+    private func makeWebViewConfiguration(userAgent: String) -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        configuration.applicationNameForUserAgent = userAgent
+        return configuration
     }
 }
 


### PR DESCRIPTION
# Expose and Align User Agent String Handling w/ Hotwire Native Android

## Motivation
Following the Android implementation (hotwired/hotwire-native-android#94), we need proper user agent string handling in iOS to ensure consistent user agent strings across WebViews and provide access to both the custom Hotwire user agent and the full WebKit user agent string.

## Changes
- Made `cachedUserAgent` internal to allow for proper testing and cache management
- Added documentation for user agent properties
- Added tests to verify user agent string generation and caching behavior
- Ensures tests properly clean up static state between runs to prevent test pollution

## Implementation Details
We're adopting a similar approach to the Android implementation where we:
1. Cache the WebKit default user agent string when a WebView is first created
2. Provide access to both:
  - The custom Hotwire user agent parts (`userAgent`)
  - The full user agent including WebKit's default (`userAgentWithWebViewDefault`)

## Testing
Added tests to verify:
- Custom user agent string generation
- Full user agent string composition
- Proper cache management between test runs

The changes ensure consistent behavior across test runs by properly cleaning up static state.