### PR TITLE
Ignore cross-origin redirects that aren’t happening in the main frame

### DIFF
--- a/Source/Turbo/Visit/ColdBootVisit.swift
+++ b/Source/Turbo/Visit/ColdBootVisit.swift
@@ -75,6 +75,13 @@ extension ColdBootVisit: WKNavigationDelegate {
             return
         }
 
+        // Allow navigation if it happens inside an iframe (sub-frame).
+        // This prevents Turbo Native from mistakenly treating iframe loads as full navigations.
+        guard let targetFrame = navigationAction.targetFrame, targetFrame.isMainFrame else {
+            decisionHandler(.allow)
+            return
+        }
+
         let isRedirect = location != url
         let redirectIsCrossOrigin = isRedirect && location.host != url.host
 

--- a/Source/Turbo/Visit/ColdBootVisit.swift
+++ b/Source/Turbo/Visit/ColdBootVisit.swift
@@ -76,7 +76,7 @@ extension ColdBootVisit: WKNavigationDelegate {
         }
 
         // Allow navigation if it happens inside an iframe (sub-frame).
-        // This prevents Turbo Native from mistakenly treating iframe loads as full navigations.
+        // This prevents iframe loads from being treated as a full navigation during cold boots.
         guard let targetFrame = navigationAction.targetFrame, targetFrame.isMainFrame else {
             decisionHandler(.allow)
             return


### PR DESCRIPTION
This PR addresses https://github.com/hotwired/hotwire-native-ios/issues/78 by ensuring that only top-level navigations are subject to cross-origin redirect checks, while allowing iframe and sub-frame navigations to proceed without interference.

This prevents unwanted redirects from embedded content (e.g., YouTube iframes) while maintaining normal navigation behaviour in the parent frame. 