### PR TITLE
Make session and modalSession public

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -19,6 +19,8 @@ public class Navigator {
         }
         return modalSession.webView
     }
+    public var session: Session
+    public var modalSession: Session
     
     /// Set to handle customize behavior of the `WKUIDelegate`.
     ///
@@ -125,8 +127,6 @@ public class Navigator {
 
     // MARK: Internal
 
-    var session: Session
-    var modalSession: Session
     /// Modifies a UINavigationController according to visit proposals.
     lazy var hierarchyController = NavigationHierarchyController(delegate: self)
 


### PR DESCRIPTION
As discussed in #89 I would want to check if a webview belongs to the session or the modalSession. This PR makes these public in the navigator, so I can access them with an extension. (I haven't added any additional code as I didn't know if this would be wanted)