### PR TITLE
Set appear reason when a modal is dismissed

### DIFF
--- a/Source/HotwireNavigationController.swift
+++ b/Source/HotwireNavigationController.swift
@@ -51,6 +51,13 @@ open class HotwireNavigationController: UINavigationController {
         return poppedViewController
     }
 
+    open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        if let topVisitableViewController = topViewController as? VisitableViewController {
+            topVisitableViewController.appearReason = .revealedByPop
+        }
+        super.dismiss(animated: flag, completion: completion)
+    }
+
     open override func viewWillAppear(_ animated: Bool) {
         if let topVisitableViewController = topViewController as? VisitableViewController,
            topVisitableViewController.disappearReason == .tabDeselected {


### PR DESCRIPTION
This PR hopes to address #88. See that issue for reproduction steps.

The fix adds an additional hook to `HotwireNavigationController` that sets `VisitableViewController.appearReason` when a modal is dismissed.