### PR TITLE
Fix unexpected modal refreshes

### DIFF
--- a/Source/Turbo/Session/Session.swift
+++ b/Source/Turbo/Session/Session.swift
@@ -274,6 +274,11 @@ extension Session: VisitableDelegate {
             visit(visitable, action: .restore)
             return
         }
+        
+        // If the topmost visitable is already the active visitable, nothing needs to be done
+        if topmostVisitable === activeVisitable {
+            return
+        }
 
         // Navigating backward from a native to a web view screen.
         if visitable === previousVisit?.visitable {


### PR DESCRIPTION
This PR attempts to address #94.

The modal refresh occurred because the `viewWillAppear` method gets triggered even when the modal was already presented and only a minor height adjustment is made (via the short pull-to-refresh gesture).

There's nothing inherently wrong here, but the [context check for the view appearance](https://github.com/hotwired/hotwire-native-ios/blob/main/Source/Turbo/Session/Session.swift#L231-L282) misinterpreted this appearance as navigating backward from a native screen to a web view.   
With the pull-to-refresh gesture, we mistakenly entered [this if check inside the context check](https://github.com/leonvogt/hotwire-native-ios/blob/1ab960be5bd957284fda8bc2085e715a41c990e9/Source/Turbo/Session/Session.swift#L283-L286):
```swift
// Navigating backward from a native to a web view screen.
if visitable === previousVisit?.visitable {
    visit(visitable, action: .restore)
}
```

To fix this, I’ve added a simple guard clause to check if the topmost visitable is already the active visitable. This prevents the modal refresh from being triggered unnecessarily.

I’ve tested all the scenarios I could think of and verified that navigating from a native screen back to a web view still works as expected and displays the correct snapshot.
I haven’t noticed any unwanted side effects so far.

However, I still feel a bit unsure about this change and would highly appreciate it if someone could review this and let me know if I might be overlooking anything.
