### PR TITLE
Improved `default` context visit behavior when dismissing the `modal` context

### DIFF
--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -106,11 +106,12 @@ class NavigationHierarchyController {
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
+            let willContextSwitch = isInModalContext
             navigationController.dismiss(animated: proposal.animated)
             pushOrReplace(on: navigationController,
                           with: controller,
                           via: proposal,
-                          didSwitchToDefaultContext: isInModalContext)
+                          didSwitchToDefaultContext: willContextSwitch)
         case .modal:
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .modal, with: proposal.options)

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -106,12 +106,12 @@ class NavigationHierarchyController {
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
-            let willContextSwitch = isInModalContext
+            let willReplaceModalContext = isInModalContext
             navigationController.dismiss(animated: proposal.animated)
             pushOrReplace(on: navigationController,
                           with: controller,
                           via: proposal,
-                          didSwitchToDefaultContext: willContextSwitch)
+                          didReplaceModalContext: willReplaceModalContext)
         case .modal:
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .modal, with: proposal.options)
@@ -131,13 +131,13 @@ class NavigationHierarchyController {
     private func pushOrReplace(on navigationController: UINavigationController,
                                with controller: UIViewController,
                                via proposal: VisitProposal,
-                               didSwitchToDefaultContext: Bool = false) {
+                               didReplaceModalContext: Bool = false) {
         
         if visitingSamePage(on: navigationController, with: controller, via: proposal.url) {
             navigationController.replaceLastViewController(with: controller)
         } else if visitingPreviousPage(on: navigationController, with: controller, via: proposal.url) {
             navigationController.popViewController(animated: proposal.animated)
-        } else if proposal.options.action == .advance || didSwitchToDefaultContext {
+        } else if proposal.options.action == .advance || didReplaceModalContext {
             navigationController.pushViewController(controller, animated: proposal.animated)
         } else {
             navigationController.replaceLastViewController(with: controller)

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -94,6 +94,11 @@ class NavigationHierarchyController {
             navigationController.present(alert, animated: proposal.animated)
         }
     }
+    
+    private var isInModalContext: Bool {
+        navigationController.presentedViewController != nil
+        && !modalNavigationController.isBeingDismissed
+    }
 
     private func navigate(with controller: UIViewController, via proposal: VisitProposal) {
         switch proposal.context {
@@ -101,15 +106,18 @@ class NavigationHierarchyController {
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
-            navigationController.dismiss(animated: proposal.animated)
-            pushOrReplace(on: navigationController, with: controller, via: proposal)
+            
+            pushOrReplace(on: navigationController,
+                          with: controller,
+                          via: proposal,
+                          didSwitchToDefaultContext: isInModalContext)
         case .modal:
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .modal, with: proposal.options)
             }
             controller.configureModalBehaviour(with: proposal)
 
-            if navigationController.presentedViewController != nil, !modalNavigationController.isBeingDismissed {
+            if isInModalContext {
                 pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
             } else {
                 modalNavigationController.setViewControllers([controller], animated: proposal.animated)
@@ -119,12 +127,16 @@ class NavigationHierarchyController {
         }
     }
 
-    private func pushOrReplace(on navigationController: UINavigationController, with controller: UIViewController, via proposal: VisitProposal) {
+    private func pushOrReplace(on navigationController: UINavigationController,
+                               with controller: UIViewController,
+                               via proposal: VisitProposal,
+                               didSwitchToDefaultContext: Bool = false) {
+        
         if visitingSamePage(on: navigationController, with: controller, via: proposal.url) {
             navigationController.replaceLastViewController(with: controller)
         } else if visitingPreviousPage(on: navigationController, with: controller, via: proposal.url) {
             navigationController.popViewController(animated: proposal.animated)
-        } else if proposal.options.action == .advance {
+        } else if proposal.options.action == .advance || didSwitchToDefaultContext {
             navigationController.pushViewController(controller, animated: proposal.animated)
         } else {
             navigationController.replaceLastViewController(with: controller)

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -106,7 +106,7 @@ class NavigationHierarchyController {
             if let visitable = controller as? Visitable {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
-            
+            navigationController.dismiss(animated: proposal.animated)
             pushOrReplace(on: navigationController,
                           with: controller,
                           via: proposal,

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -214,6 +214,36 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
         assertVisited(url: proposal.url, on: .modal)
     }
+    
+    func test_modal_default_default_replaceAction_pushesOnMainStack_ifDifferentDestination() {
+        navigator.route(VisitProposal(path: "/one", context: .default))
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        
+        navigator.route(VisitProposal(path: "/two", context: .modal))
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
+
+        let proposal = VisitProposal(path: "/three", action: .replace, context: .default)
+        navigator.route(proposal)
+        
+        XCTAssertNil(navigationController.presentedViewController)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        assertVisited(url: proposal.url, on: .main)
+    }
+    
+    func test_modal_default_default_replaceAction_replacesOnMainStack_ifSameDestination() {
+        navigator.route(VisitProposal(path: "/one", context: .default))
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        
+        navigator.route(VisitProposal(path: "/two", context: .modal))
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
+
+        let proposal = VisitProposal(path: "/one", action: .replace, context: .default)
+        navigator.route(proposal)
+        
+        XCTAssertNil(navigationController.presentedViewController)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        assertVisited(url: proposal.url, on: .main)
+    }
 
     func test_modal_modal_replace_pushesOnModalStack() {
         navigator.route(VisitProposal(path: "/one", context: .modal))
@@ -439,7 +469,8 @@ private extension VisitProposal {
         let options = VisitOptions(action: action, response: nil)
         let defaultProperties: PathProperties = [
             "context": context.rawValue,
-            "presentation": presentation.rawValue
+            "presentation": presentation.rawValue,
+            "animated": false,
         ]
         let properties = defaultProperties.merging(additionalProperties) { (current, _) in current }
 

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -469,8 +469,7 @@ private extension VisitProposal {
         let options = VisitOptions(action: action, response: nil)
         let defaultProperties: PathProperties = [
             "context": context.rawValue,
-            "presentation": presentation.rawValue,
-            "animated": false,
+            "presentation": presentation.rawValue
         ]
         let properties = defaultProperties.merging(additionalProperties) { (current, _) in current }
 


### PR DESCRIPTION
This PR fixes an issue when you're in the `modal` context and a visit is proposed to the `default` context. If that visit proposal contains a `replace` action, we don't want to both dismiss the modal screen *and* then `replace` the underlying `default` context screen. That can lead to replacing the `default` context screen that should be preserved, such as the root destination.

The only scenario where we'll both dismiss the modal screen and `replace` is if the underlying `default` context is the same URL as the proposed URL.