### PR TITLE
Fix unremoved screenshot - feedback

### DIFF
--- a/Source/HotwireNavigationController.swift
+++ b/Source/HotwireNavigationController.swift
@@ -51,6 +51,13 @@ open class HotwireNavigationController: UINavigationController {
         return poppedViewController
     }
 
+    open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        if let topVisitableViewController = topViewController as? VisitableViewController {
+            topVisitableViewController.appearReason = .revealedByPop
+        }
+        super.dismiss(animated: flag, completion: completion)
+    }
+
     open override func viewWillAppear(_ animated: Bool) {
         if let topVisitableViewController = topViewController as? VisitableViewController,
            topVisitableViewController.disappearReason == .tabDeselected {

--- a/Source/HotwireNavigationController.swift
+++ b/Source/HotwireNavigationController.swift
@@ -53,9 +53,16 @@ open class HotwireNavigationController: UINavigationController {
 
     open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         if let topVisitableViewController = topViewController as? VisitableViewController {
-            topVisitableViewController.appearReason = .revealedByPop
+            topVisitableViewController.appearReason = .revealedByModalDismiss
         }
         super.dismiss(animated: flag, completion: completion)
+    }
+
+    open override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        if let topVisitableViewController = topViewController as? VisitableViewController {
+            topVisitableViewController.disappearReason = .coveredByModal
+        }
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
     }
 
     open override func viewWillAppear(_ animated: Bool) {

--- a/Source/Turbo/Visitable/VisitableViewController.swift
+++ b/Source/Turbo/Visitable/VisitableViewController.swift
@@ -4,8 +4,8 @@ import WebKit
 open class VisitableViewController: UIViewController, Visitable {
     open weak var visitableDelegate: VisitableDelegate?
     open var visitableURL: URL!
-    var appearReason: AppearReason = .pushedOntoNavigationStack
-    var disappearReason: DisappearReason = .poppedFromNavigationStack
+    open var appearReason: AppearReason = .pushedOntoNavigationStack
+    open var disappearReason: DisappearReason = .poppedFromNavigationStack
 
     public convenience init(url: URL) {
         self.init()

--- a/Source/Turbo/Visitable/VisitableViewController.swift
+++ b/Source/Turbo/Visitable/VisitableViewController.swift
@@ -90,11 +90,13 @@ extension VisitableViewController {
         case pushedOntoNavigationStack
         case revealedByPop
         case tabSelected
+        case revealedByModalDismiss
     }
 
     public enum DisappearReason {
         case coveredByPush
         case poppedFromNavigationStack
         case tabDeselected
+        case coveredByModal
     }
 }


### PR DESCRIPTION
This PR builds on top of https://github.com/hotwired/hotwire-native-ios/pull/91.
It introduces explicit appear and disappear reasons when presenting/dismissing a modal. Even though the new reasons are currently not used anywhere, I think it makes sense to be explicit.

This PR also addresses https://github.com/hotwired/hotwire-native-ios/issues/82 by making the `VisitableViewController`'s `appearReason` and `disappearReason` `open`.

NOTE: Since tabs are a heavily used UI pattern, we should consider implementing a Hotwire Native tab bar controller.