### PR TITLE
Route decision handlers

### DIFF
--- a/Demo/NumbersViewController.swift
+++ b/Demo/NumbersViewController.swift
@@ -6,14 +6,14 @@ import UIKit
 final class NumbersViewController: UITableViewController, PathConfigurationIdentifiable {
     static var pathConfigurationIdentifier: String { "numbers" }
 
-    convenience init(url: URL, navigator: Router) {
+    convenience init(url: URL, navigator: NavigationHandler) {
         self.init(nibName: nil, bundle: nil)
         self.url = url
         self.navigator = navigator
     }
 
     private var url: URL!
-    private unowned var navigator: Router?
+    private unowned var navigator: NavigationHandler?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -7,7 +7,10 @@ final class SceneController: UIResponder {
     var window: UIWindow?
 
     private let rootURL = Demo.current
-    private lazy var navigator = Navigator(delegate: self)
+    private lazy var navigator = Navigator(
+        configuration: .init(name: "main", startLocation: rootURL),
+        delegate: self
+    )
 
     // MARK: - Authentication
 

--- a/Source/Hotwire.swift
+++ b/Source/Hotwire.swift
@@ -13,6 +13,10 @@ public enum Hotwire {
     }
 
 
+    public static func registerRouteDecisionHandlers(_ decisionHandlers: [any RouteDecisionHandler]) {
+        config.router = Router(decisionHandlers: decisionHandlers)
+    }
+
     /// Loads the `PathConfiguration` JSON file(s) from the provided sources
     /// to configure navigation rules
     /// - Parameter sources: An array of `PathConfiguration.Source` objects representing

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -97,7 +97,11 @@ public struct HotwireConfig {
 
     private let sharedProcessPool = WKProcessPool()
 
-    var router = Router(decisionHandlers: [])
+    var router = Router(decisionHandlers: [
+        AppNavigationRouteDecisionHandler(),
+        BrowserRouteDecisionHandler()
+    ]
+    )
 
     // A method (not a property) because we need a new instance for each web view.
     private func makeWebViewConfiguration() -> WKWebViewConfiguration {

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -97,6 +97,8 @@ public struct HotwireConfig {
 
     private let sharedProcessPool = WKProcessPool()
 
+    var router = Router(decisionHandlers: [])
+
     // A method (not a property) because we need a new instance for each web view.
     private func makeWebViewConfiguration() -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -69,6 +69,8 @@ public struct HotwireConfig {
         WKWebView.debugInspectable(configuration: configuration)
     }
 
+    public var defaultExternalURLOpeningOption: ExternalURLOpeningOption = .safari
+
     // MARK: Bridge
 
     /// Set a custom JSON encoder when parsing bridge payloads.

--- a/Source/NavigationHandler.swift
+++ b/Source/NavigationHandler.swift
@@ -9,13 +9,13 @@ import Foundation
 /// circular dependency between the two.
 ///
 /// - Note: See `NumbersViewController` in the demo app for an example.
-public protocol Router: AnyObject {
+public protocol NavigationHandler: AnyObject {
     func route(_ url: URL)
 
     func route(_ proposal: VisitProposal)
 }
 
-extension Navigator: Router {
+extension Navigator: NavigationHandler {
     public func route(_ url: URL) {
         route(url, options: VisitOptions(action: .advance), parameters: nil)
     }

--- a/Source/Turbo/Navigator/Extensions/WKNavigationAction+Utils.swift
+++ b/Source/Turbo/Navigator/Extensions/WKNavigationAction+Utils.swift
@@ -1,0 +1,7 @@
+import WebKit
+
+extension WKNavigationAction {
+    var isMainFrameNavigation: Bool {
+        targetFrame?.isMainFrame ?? false
+    }
+}

--- a/Source/Turbo/Navigator/Helpers/ExternalURLNavigationAction.swift
+++ b/Source/Turbo/Navigator/Helpers/ExternalURLNavigationAction.swift
@@ -1,14 +1,15 @@
 import Foundation
 
-/// When `Navigator` encounters an external URL, its delegate may handle it with any of these actions.
-public enum ExternalURLNavigationAction {
-    /// Attempts to open via an embedded `SafariViewController` so the user stays in-app.
-    /// Silently fails if you pass a URL that's not `http` or `https`.
-    case openViaSafariController
+/// Defines how external URLs should be opened. This enum is used in `BrowserRouteDecisionHandler`.
+/// However, you can also write your own implementation for handling external URLs and reuse this enum.
+public enum ExternalURLOpeningOption {
+    /// Open via an embedded `SafariViewController` so the user stays in-app.
+    /// NOTE: This will silently fail for a URL that's not `http` or `https`.
+    case safari
 
-    /// Attempts to open via `openURL(_:options:completionHandler)`.
+    /// Open via `openURL(_:options:completionHandler)`.
     /// This is useful if the external URL is a deeplink.
-    case openViaSystem
+    case system
 
     /// Will do nothing with the external URL.
     case reject

--- a/Source/Turbo/Navigator/Navigator+Configuration.swift
+++ b/Source/Turbo/Navigator/Navigator+Configuration.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public extension Navigator {
+    struct Configuration {
+        public let name: String
+        public let startLocation: URL
+
+        public init(name: String, startLocation: URL) {
+            self.name = name
+            self.startLocation = startLocation
+        }
+    }
+}

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -174,7 +174,10 @@ public class Navigator {
     }
 
     private func routeDecision(for location: URL) -> Router.Decision {
-        return Hotwire.config.router.decideRoute(for: location)
+        return Hotwire.config.router.decideRoute(
+            for: location,
+            activeNavigationController: activeNavigationController
+        )
     }
 }
 
@@ -220,7 +223,10 @@ extension Navigator: SessionDelegate {
     }
 
     public func session(_ session: Session, decidePolicyFor navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
-        return Hotwire.config.router.decidePolicy(for: navigationAction)
+        return Hotwire.config.router.decidePolicy(
+            for: navigationAction,
+            activeNavigationController: activeNavigationController
+        )
     }
 
     public func sessionWebViewProcessDidTerminate(_ session: Session) {

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -155,7 +155,7 @@ public class Navigator {
         return Hotwire.config.router.decideRoute(
             for: location,
             configuration: configuration,
-            activeNavigationController: activeNavigationController
+            navigator: self
         )
     }
 }
@@ -199,7 +199,7 @@ extension Navigator: SessionDelegate {
         return Hotwire.config.router.decidePolicy(
             for: navigationAction,
             configuration: configuration,
-            activeNavigationController: activeNavigationController
+            navigator: self
         )
     }
 

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -34,14 +34,14 @@ public class Navigator {
     /// Convenience initializer that doesn't require manually creating `Session` instances.
     /// - Parameters:
     ///   - delegate: _optional:_ delegate to handle custom view controllers
-    public convenience init(delegate: NavigatorDelegate? = nil) {
+    public convenience init(configuration: Navigator.Configuration, delegate: NavigatorDelegate? = nil) {
         let session = Session(webView: Hotwire.config.makeWebView())
         session.pathConfiguration = Hotwire.config.pathConfiguration
 
         let modalSession = Session(webView: Hotwire.config.makeWebView())
         modalSession.pathConfiguration = Hotwire.config.pathConfiguration
 
-        self.init(session: session, modalSession: modalSession, delegate: delegate)
+        self.init(session: session, modalSession: modalSession, delegate: delegate, configuration: configuration)
     }
 
     /// Transforms `URL` -> `VisitProposal` -> `UIViewController`.
@@ -141,9 +141,13 @@ public class Navigator {
     ///   - session: the main `Session`
     ///   - modalSession: the `Session` used for the modal navigation controller
     ///   - delegate: _optional:_ delegate to handle custom view controllers
-    init(session: Session, modalSession: Session, delegate: NavigatorDelegate? = nil) {
+    init(session: Session,
+         modalSession: Session,
+         delegate: NavigatorDelegate? = nil,
+         configuration: Navigator.Configuration) {
         self.session = session
         self.modalSession = modalSession
+        self.configuration = configuration
 
         self.delegate = delegate ?? navigatorDelegate
 
@@ -161,6 +165,7 @@ public class Navigator {
     private let navigatorDelegate = DefaultNavigatorDelegate()
     private var backgroundTerminatedWebViewSessions = [Session]()
     private var appInBackground = false
+    private let configuration: Navigator.Configuration
 
     private func controller(for proposal: VisitProposal) -> UIViewController? {
         switch delegate.handle(proposal: proposal) {
@@ -176,6 +181,7 @@ public class Navigator {
     private func routeDecision(for location: URL) -> Router.Decision {
         return Hotwire.config.router.decideRoute(
             for: location,
+            configuration: configuration,
             activeNavigationController: activeNavigationController
         )
     }
@@ -225,6 +231,7 @@ extension Navigator: SessionDelegate {
     public func session(_ session: Session, decidePolicyFor navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
         return Hotwire.config.router.decidePolicy(
             for: navigationAction,
+            configuration: configuration,
             activeNavigationController: activeNavigationController
         )
     }

--- a/Source/Turbo/Navigator/NavigatorDelegate.swift
+++ b/Source/Turbo/Navigator/NavigatorDelegate.swift
@@ -15,8 +15,6 @@ public protocol NavigatorDelegate: AnyObject {
     /// - Returns:`ProposalResult` - how to react to the visit proposal
     func handle(proposal: VisitProposal) -> ProposalResult
 
-    func handle(externalURL: URL) -> ExternalURLNavigationAction
-
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
     /// - Important: If not implemented, will present the error's localized description and a Retry button.
@@ -38,10 +36,6 @@ public protocol NavigatorDelegate: AnyObject {
 public extension NavigatorDelegate {
     func handle(proposal: VisitProposal) -> ProposalResult {
         .accept
-    }
-
-    func handle(externalURL: URL) -> ExternalURLNavigationAction {
-        .openViaSafariController
     }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retryHandler: RetryBlock?) {

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -6,20 +6,34 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
     let decision: Router.Decision = .navigate
     let navigationActionPolicy: WKNavigationActionPolicy = .cancel
 
-    func matches(location: URL) -> Bool {
-        // TODO: Provide a base URL
-        return true
+    func matches(location: URL,
+                 configuration: Navigator.Configuration) -> Bool {
+        if #available(iOS 16, *) {
+            return configuration.startLocation.host() == location.host()
+        }
+
+        return configuration.startLocation.host == location.host
     }
 
-    func handle(location: URL, activeNavigationController: UINavigationController) {
+    func handle(location: URL,
+                configuration: Navigator.Configuration,
+                activeNavigationController: UINavigationController) {
         // No-op.
     }
 
-    func matches(navigationAction: WKNavigationAction) -> Bool {
-        return navigationAction.navigationType == .linkActivated
+    func matches(navigationAction: WKNavigationAction,
+                 configuration: Navigator.Configuration) -> Bool {
+        guard let url = navigationAction.request.url else {
+            return false
+        }
+
+        return navigationAction.navigationType == .linkActivated &&
+        matches(location: url, configuration: configuration)
     }
 
-    func handle(navigationAction: WKNavigationAction, activeNavigationController: UINavigationController) {
+    func handle(navigationAction: WKNavigationAction,
+                configuration: Navigator.Configuration,
+                activeNavigationController: UINavigationController) {
         // No-op.
     }
 }

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -11,7 +11,7 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
         return true
     }
 
-    func handle(location: URL) {
+    func handle(location: URL, activeNavigationController: UINavigationController) {
         // No-op.
     }
 
@@ -19,7 +19,7 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
         return navigationAction.navigationType == .linkActivated
     }
 
-    func handle(navigationAction: WKNavigationAction) {
+    func handle(navigationAction: WKNavigationAction, activeNavigationController: UINavigationController) {
         // No-op.
     }
 }

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -44,4 +44,3 @@ private extension WKNavigationAction {
         isMainFrameNavigation
     }
 }
-

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -17,7 +17,7 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
 
     func handle(location: URL,
                 configuration: Navigator.Configuration,
-                activeNavigationController: UINavigationController) {
+                navigator: Navigator) {
         // No-op.
     }
 
@@ -33,7 +33,7 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
 
     func handle(navigationAction: WKNavigationAction,
                 configuration: Navigator.Configuration,
-                activeNavigationController: UINavigationController) {
+                navigator: Navigator) {
         // No-op.
     }
 }

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -27,7 +27,7 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
             return false
         }
 
-        return navigationAction.navigationType == .linkActivated &&
+        return navigationAction.shouldNavigateInApp &&
         matches(location: url, configuration: configuration)
     }
 
@@ -37,3 +37,11 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
         // No-op.
     }
 }
+
+private extension WKNavigationAction {
+    var shouldNavigateInApp: Bool {
+        navigationType == .linkActivated ||
+        isMainFrameNavigation
+    }
+}
+

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -1,0 +1,25 @@
+import Foundation
+import WebKit
+
+final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
+    let name: String = "app-navigation"
+    let decision: Router.Decision = .navigate
+    let navigationActionPolicy: WKNavigationActionPolicy = .cancel
+
+    func matches(location: URL) -> Bool {
+        // TODO: Provide a base URL
+        return true
+    }
+
+    func handle(location: URL) {
+        // No-op.
+    }
+
+    func matches(navigationAction: WKNavigationAction) -> Bool {
+        return navigationAction.navigationType == .linkActivated
+    }
+
+    func handle(navigationAction: WKNavigationAction) {
+        // No-op.
+    }
+}

--- a/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/AppNavigationRouteDecisionHandler.swift
@@ -34,7 +34,15 @@ final class AppNavigationRouteDecisionHandler: RouteDecisionHandler {
     func handle(navigationAction: WKNavigationAction,
                 configuration: Navigator.Configuration,
                 navigator: Navigator) {
-        // No-op.
+        guard let url = navigationAction.request.url else {
+            return
+        }
+
+        // Explicitly handle target="_blank" links by routing them through the navigator.
+        if navigationAction.navigationType == .linkActivated &&
+            navigationAction.requestsNewWindow {
+            navigator.route(url)
+        }
     }
 }
 
@@ -42,5 +50,11 @@ private extension WKNavigationAction {
     var shouldNavigateInApp: Bool {
         navigationType == .linkActivated ||
         isMainFrameNavigation
+    }
+
+    /// Indicates if the navigation action requests a new window (e.g., target="_blank").
+    var requestsNewWindow: Bool {
+        guard let targetFrame else { return true }
+        return !targetFrame.isMainFrame
     }
 }

--- a/Source/Turbo/Navigator/Routing/BrowserRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/BrowserRouteDecisionHandler.swift
@@ -1,0 +1,35 @@
+import Foundation
+import WebKit
+import SafariServices
+
+final class BrowserRouteDecisionHandler: RouteDecisionHandler {
+    let name: String = "browser"
+    let decision: Router.Decision = .cancel
+    let navigationActionPolicy: WKNavigationActionPolicy = .cancel
+
+    func matches(location: URL) -> Bool {
+        // TODO: Provide a base URL
+        return true
+    }
+
+    func handle(location: URL, activeNavigationController: UINavigationController) {
+        /// SFSafariViewController will crash if we pass along a URL that's not valid.
+        guard location.scheme == "http" || location.scheme == "https" else { return }
+
+        let safariViewController = SFSafariViewController(url: location)
+        safariViewController.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *) {
+            safariViewController.preferredControlTintColor = .tintColor
+        }
+
+        activeNavigationController.present(safariViewController, animated: true)
+    }
+
+    func matches(navigationAction: WKNavigationAction) -> Bool {
+        return navigationAction.navigationType == .linkActivated
+    }
+
+    func handle(navigationAction: WKNavigationAction, activeNavigationController: UINavigationController) {
+        // No-op.
+    }
+}

--- a/Source/Turbo/Navigator/Routing/BrowserRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/BrowserRouteDecisionHandler.swift
@@ -29,7 +29,7 @@ final class BrowserRouteDecisionHandler: RouteDecisionHandler {
             return false
         }
 
-        return navigationAction.navigationType == .linkActivated &&
+        return navigationAction.shouldOpenURLExternally &&
         matches(location: url, configuration: configuration)
     }
 
@@ -71,5 +71,12 @@ final class BrowserRouteDecisionHandler: RouteDecisionHandler {
         case .reject:
             return
         }
+    }
+}
+
+private extension WKNavigationAction {
+    var shouldOpenURLExternally: Bool {
+        return navigationType == .linkActivated ||
+        (isMainFrameNavigation && navigationType == .other)
     }
 }

--- a/Source/Turbo/Navigator/Routing/BrowserRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/BrowserRouteDecisionHandler.swift
@@ -18,9 +18,9 @@ final class BrowserRouteDecisionHandler: RouteDecisionHandler {
 
     func handle(location: URL,
                 configuration: Navigator.Configuration,
-                activeNavigationController: UINavigationController) {
+                navigator: Navigator) {
         open(externalURL: location,
-             activeNavigationController: activeNavigationController)
+             activeNavigationController: navigator.activeNavigationController)
     }
 
     func matches(navigationAction: WKNavigationAction,
@@ -35,21 +35,21 @@ final class BrowserRouteDecisionHandler: RouteDecisionHandler {
 
     func handle(navigationAction: WKNavigationAction,
                 configuration: Navigator.Configuration,
-                activeNavigationController: UINavigationController) {
+                navigator: Navigator) {
         guard let url = navigationAction.request.url else {
             return
         }
 
         handle(location: url,
                configuration: configuration,
-               activeNavigationController: activeNavigationController)
+               navigator: navigator)
     }
 
     /// Navigate to an external URL.
     ///
     /// - Parameters:
-    ///   - externalURL: the URL to navigate to
-    ///   - via: navigation action
+    ///   - externalURL: The URL to navigate to.
+    ///   - activeNavigationController: The active navigation controller.
     public func open(externalURL: URL,
                      activeNavigationController: UINavigationController) {
         switch Hotwire.config.defaultExternalURLOpeningOption {

--- a/Source/Turbo/Navigator/Routing/RouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/RouteDecisionHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+import WebKit
+
+public protocol RouteDecisionHandler {
+    var name: String { get }
+    var decision: Router.Decision { get }
+    var navigationActionPolicy: WKNavigationActionPolicy { get }
+
+    /// Determines whether the location matches this decision handler.
+    /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
+    /// - Parameter location: The location URL.
+    /// - Returns: `true` if location matches this decision handler, `false` otherwise.
+    func matches(location: URL,
+                 configuration: Navigator.Configuration) -> Bool
+
+    /// Handle custom routing behavior when a match is found.
+    /// For example, open an external browser or app for external domain urls.
+    /// - Parameter location: The location URL.
+    func handle(location: URL,
+                configuration: Navigator.Configuration,
+                navigator: Navigator)
+
+    func matches(navigationAction: WKNavigationAction,
+                 configuration: Navigator.Configuration) -> Bool
+
+    func handle(navigationAction: WKNavigationAction,
+                configuration: Navigator.Configuration,
+                navigator: Navigator)
+}

--- a/Source/Turbo/Navigator/Routing/RouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/RouteDecisionHandler.swift
@@ -1,28 +1,54 @@
 import Foundation
 import WebKit
 
+/// An interface to implement to provide custom
+/// route decision handling behaviors in your app.
 public protocol RouteDecisionHandler {
+    /// The decision handler name used in debug logging.
     var name: String { get }
+
+    /// To permit in-app navigation when the location matches this decision
+    /// handler, return `navigate`. To prevent in-app navigation return `cancel`.
     var decision: Router.Decision { get }
+
+    /// To permit web view navigation when the navigation action matches this decision
+    /// handler, return `allow`. To prevent the web view navigation return `cancel`.
     var navigationActionPolicy: WKNavigationActionPolicy { get }
 
     /// Determines whether the location matches this decision handler.
     /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
-    /// - Parameter location: The location URL.
+    /// - Parameters:
+    ///     - location: The location URL.
+    ///     - configuration: The configuration of the navigator where the navigation is taking place.
     /// - Returns: `true` if location matches this decision handler, `false` otherwise.
     func matches(location: URL,
                  configuration: Navigator.Configuration) -> Bool
 
     /// Handle custom routing behavior when a match is found.
     /// For example, open an external browser or app for external domain urls.
-    /// - Parameter location: The location URL.
+    /// - Parameters:
+    ///     - location: The location URL.
+    ///     - configuration: The configuration of the navigator where the navigation is taking place.
+    ///     - navigator: The navigator instance responsible for the navigation.
     func handle(location: URL,
                 configuration: Navigator.Configuration,
                 navigator: Navigator)
 
+    /// Determines whether the navigation action from the web view matches this decision handler.
+    /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
+    /// - Parameters:
+    ///     - navigationAction: A `WKNavigationAction` instance.
+    ///     - configuration: The configuration of the navigator where the navigation is taking place.
+    /// - Returns: `true` if navigation action matches this decision handler, `false` otherwise.
     func matches(navigationAction: WKNavigationAction,
                  configuration: Navigator.Configuration) -> Bool
 
+    /// Handle custom routing behavior when a match is found.
+    /// For example, open an external browser or app for external domain urls.
+    /// - Parameters:
+    ///     - navigationAction: A `WKNavigationAction` instance.
+    ///     - configuration: The configuration of the navigator where the navigation is taking place.
+    ///     - navigator: The navigator instance responsible for the navigation.
     func handle(navigationAction: WKNavigationAction,
                 configuration: Navigator.Configuration,
                 navigator: Navigator)

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -8,10 +8,12 @@ public final class Router {
         self.decisionHandlers = decisionHandlers
     }
 
-    func decideRoute(for location: URL) -> Decision {
+    func decideRoute(for location: URL,
+                     activeNavigationController: UINavigationController) -> Decision {
         for handler in decisionHandlers {
             if handler.matches(location: location) {
-                handler.handle(location: location)
+                handler.handle(location: location,
+                               activeNavigationController: activeNavigationController)
                 return handler.decision
             }
         }
@@ -19,10 +21,12 @@ public final class Router {
         return .cancel
     }
 
-    func decidePolicy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
+    func decidePolicy(for navigationAction: WKNavigationAction,
+                      activeNavigationController: UINavigationController) -> WKNavigationActionPolicy {
         for handler in decisionHandlers {
             if handler.matches(navigationAction: navigationAction) {
-                handler.handle(navigationAction: navigationAction)
+                handler.handle(navigationAction: navigationAction,
+                               activeNavigationController: activeNavigationController)
                 return handler.navigationActionPolicy
             }
         }
@@ -52,8 +56,8 @@ public protocol RouteDecisionHandler {
     /// Handle custom routing behavior when a match is found.
     /// For example, open an external browser or app for external domain urls.
     /// - Parameter location: The location URL.
-    func handle(location: URL)
+    func handle(location: URL, activeNavigationController: UINavigationController)
 
     func matches(navigationAction: WKNavigationAction) -> Bool
-    func handle(navigationAction: WKNavigationAction)
+    func handle(navigationAction: WKNavigationAction, activeNavigationController: UINavigationController)
 }

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -10,12 +10,12 @@ public final class Router {
 
     func decideRoute(for location: URL,
                      configuration: Navigator.Configuration,
-                     activeNavigationController: UINavigationController) -> Decision {
+                     navigator: Navigator) -> Decision {
         for handler in decisionHandlers {
             if handler.matches(location: location, configuration: configuration) {
                 handler.handle(location: location,
                                configuration: configuration,
-                               activeNavigationController: activeNavigationController)
+                               navigator: navigator)
                 return handler.decision
             }
         }
@@ -25,12 +25,12 @@ public final class Router {
 
     func decidePolicy(for navigationAction: WKNavigationAction,
                       configuration: Navigator.Configuration,
-                      activeNavigationController: UINavigationController) -> WKNavigationActionPolicy {
+                      navigator: Navigator) -> WKNavigationActionPolicy {
         for handler in decisionHandlers {
             if handler.matches(navigationAction: navigationAction, configuration: configuration) {
                 handler.handle(navigationAction: navigationAction,
                                configuration: configuration,
-                               activeNavigationController: activeNavigationController)
+                               navigator: navigator)
                 return handler.navigationActionPolicy
             }
         }
@@ -63,12 +63,12 @@ public protocol RouteDecisionHandler {
     /// - Parameter location: The location URL.
     func handle(location: URL,
                 configuration: Navigator.Configuration,
-                activeNavigationController: UINavigationController)
+                navigator: Navigator)
 
     func matches(navigationAction: WKNavigationAction,
                  configuration: Navigator.Configuration) -> Bool
 
     func handle(navigationAction: WKNavigationAction,
                 configuration: Navigator.Configuration,
-                activeNavigationController: UINavigationController)
+                navigator: Navigator)
 }

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -1,6 +1,8 @@
 import Foundation
 import WebKit
 
+/// Routes location urls within in-app navigation or with custom behaviors
+/// provided in `RouteDecisionHandler` instances.
 public final class Router {
     let decisionHandlers: [RouteDecisionHandler]
 
@@ -16,10 +18,12 @@ public final class Router {
                 handler.handle(location: location,
                                configuration: configuration,
                                navigator: navigator)
+                logger.debug("[Router] handler match found handler: \(handler.name) location: \(location)")
                 return handler.decision
             }
         }
 
+        logger.warning("[Router] no handler for location: \(location)")
         return .cancel
     }
 
@@ -31,17 +35,21 @@ public final class Router {
                 handler.handle(navigationAction: navigationAction,
                                configuration: configuration,
                                navigator: navigator)
+                logger.debug("[Router] handler match found handler: \(handler.name) navigation action: \(navigationAction)")
                 return handler.navigationActionPolicy
             }
         }
 
+        logger.warning("[Router] no handler for navigation action: \(navigationAction)")
         return .allow
     }
 }
 
 public extension Router {
     enum Decision {
+        /// Permit in-app navigation with your app's domain urls.
         case navigate
+        /// Prevent in-app navigation. Always use this for external domain urls.
         case cancel
     }
 }

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -1,0 +1,52 @@
+import Foundation
+import WebKit
+
+final class Router {
+    let decisionHandlers: [RouteDecisionHandler]
+
+    init(decisionHandlers: [RouteDecisionHandler]) {
+        self.decisionHandlers = decisionHandlers
+    }
+
+    func decideRoute(for location: String) -> Decision {
+        for handler in decisionHandlers {
+            if handler.matches(location: location) {
+                handler.handle(location: location)
+                return handler.decision
+            }
+        }
+
+        return .cancel
+    }
+
+//    func decidePolicy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
+//        for handler in decisionHandlers {
+//
+//        }
+//    }
+}
+
+extension Router {
+    enum Decision {
+        case navigate
+        case cancel
+    }
+}
+
+protocol RouteDecisionHandler {
+    var name: String { get }
+    var decision: Router.Decision { get }
+
+    func decidePolicy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy
+
+    /// Determines whether the location matches this decision handler.
+    /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
+    /// - Parameter location: <#location description#>
+    /// - Returns: <#description#>
+    func matches(location: String) -> Bool
+
+    /// Handle custom routing behavior when a match is found.
+    /// For example, open an external browser or app for external domain urls.
+    /// - Parameter location: <#location description#>
+    func handle(location: String)
+}

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -9,10 +9,12 @@ public final class Router {
     }
 
     func decideRoute(for location: URL,
+                     configuration: Navigator.Configuration,
                      activeNavigationController: UINavigationController) -> Decision {
         for handler in decisionHandlers {
-            if handler.matches(location: location) {
+            if handler.matches(location: location, configuration: configuration) {
                 handler.handle(location: location,
+                               configuration: configuration,
                                activeNavigationController: activeNavigationController)
                 return handler.decision
             }
@@ -22,10 +24,12 @@ public final class Router {
     }
 
     func decidePolicy(for navigationAction: WKNavigationAction,
+                      configuration: Navigator.Configuration,
                       activeNavigationController: UINavigationController) -> WKNavigationActionPolicy {
         for handler in decisionHandlers {
-            if handler.matches(navigationAction: navigationAction) {
+            if handler.matches(navigationAction: navigationAction, configuration: configuration) {
                 handler.handle(navigationAction: navigationAction,
+                               configuration: configuration,
                                activeNavigationController: activeNavigationController)
                 return handler.navigationActionPolicy
             }
@@ -51,13 +55,20 @@ public protocol RouteDecisionHandler {
     /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
     /// - Parameter location: The location URL.
     /// - Returns: `true` if location matches this decision handler, `false` otherwise.
-    func matches(location: URL) -> Bool
+    func matches(location: URL,
+                 configuration: Navigator.Configuration) -> Bool
 
     /// Handle custom routing behavior when a match is found.
     /// For example, open an external browser or app for external domain urls.
     /// - Parameter location: The location URL.
-    func handle(location: URL, activeNavigationController: UINavigationController)
+    func handle(location: URL,
+                configuration: Navigator.Configuration,
+                activeNavigationController: UINavigationController)
 
-    func matches(navigationAction: WKNavigationAction) -> Bool
-    func handle(navigationAction: WKNavigationAction, activeNavigationController: UINavigationController)
+    func matches(navigationAction: WKNavigationAction,
+                 configuration: Navigator.Configuration) -> Bool
+
+    func handle(navigationAction: WKNavigationAction,
+                configuration: Navigator.Configuration,
+                activeNavigationController: UINavigationController)
 }

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -45,30 +45,3 @@ public extension Router {
         case cancel
     }
 }
-
-public protocol RouteDecisionHandler {
-    var name: String { get }
-    var decision: Router.Decision { get }
-    var navigationActionPolicy: WKNavigationActionPolicy { get }
-
-    /// Determines whether the location matches this decision handler.
-    /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
-    /// - Parameter location: The location URL.
-    /// - Returns: `true` if location matches this decision handler, `false` otherwise.
-    func matches(location: URL,
-                 configuration: Navigator.Configuration) -> Bool
-
-    /// Handle custom routing behavior when a match is found.
-    /// For example, open an external browser or app for external domain urls.
-    /// - Parameter location: The location URL.
-    func handle(location: URL,
-                configuration: Navigator.Configuration,
-                navigator: Navigator)
-
-    func matches(navigationAction: WKNavigationAction,
-                 configuration: Navigator.Configuration) -> Bool
-
-    func handle(navigationAction: WKNavigationAction,
-                configuration: Navigator.Configuration,
-                navigator: Navigator)
-}

--- a/Source/Turbo/Navigator/Routing/Router.swift
+++ b/Source/Turbo/Navigator/Routing/Router.swift
@@ -1,14 +1,14 @@
 import Foundation
 import WebKit
 
-final class Router {
+public final class Router {
     let decisionHandlers: [RouteDecisionHandler]
 
     init(decisionHandlers: [RouteDecisionHandler]) {
         self.decisionHandlers = decisionHandlers
     }
 
-    func decideRoute(for location: String) -> Decision {
+    func decideRoute(for location: URL) -> Decision {
         for handler in decisionHandlers {
             if handler.matches(location: location) {
                 handler.handle(location: location)
@@ -19,34 +19,41 @@ final class Router {
         return .cancel
     }
 
-//    func decidePolicy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
-//        for handler in decisionHandlers {
-//
-//        }
-//    }
+    func decidePolicy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
+        for handler in decisionHandlers {
+            if handler.matches(navigationAction: navigationAction) {
+                handler.handle(navigationAction: navigationAction)
+                return handler.navigationActionPolicy
+            }
+        }
+
+        return .allow
+    }
 }
 
-extension Router {
+public extension Router {
     enum Decision {
         case navigate
         case cancel
     }
 }
 
-protocol RouteDecisionHandler {
+public protocol RouteDecisionHandler {
     var name: String { get }
     var decision: Router.Decision { get }
-
-    func decidePolicy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy
+    var navigationActionPolicy: WKNavigationActionPolicy { get }
 
     /// Determines whether the location matches this decision handler.
     /// Use your own custom rules based on the location's domain, protocol, path, or any other factors.
-    /// - Parameter location: <#location description#>
-    /// - Returns: <#description#>
-    func matches(location: String) -> Bool
+    /// - Parameter location: The location URL.
+    /// - Returns: `true` if location matches this decision handler, `false` otherwise.
+    func matches(location: URL) -> Bool
 
     /// Handle custom routing behavior when a match is found.
     /// For example, open an external browser or app for external domain urls.
-    /// - Parameter location: <#location description#>
-    func handle(location: String)
+    /// - Parameter location: The location URL.
+    func handle(location: URL)
+
+    func matches(navigationAction: WKNavigationAction) -> Bool
+    func handle(navigationAction: WKNavigationAction)
 }

--- a/Source/Turbo/Session/SessionDelegate.swift
+++ b/Source/Turbo/Session/SessionDelegate.swift
@@ -6,7 +6,6 @@ public protocol SessionDelegate: AnyObject {
     func session(_ session: Session,  didProposeVisitToCrossOriginRedirect location: URL)
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
 
-    func session(_ session: Session, openExternalURL url: URL)
     func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     func session(_ session: Session, decidePolicyFor navigationAction: WKNavigationAction) -> WKNavigationActionPolicy
 
@@ -23,11 +22,6 @@ public extension SessionDelegate {
     func sessionDidLoadWebView(_ session: Session) {
         session.webView.navigationDelegate = session
     }
-
-    func session(_ session: Session, openExternalURL url: URL) {
-        UIApplication.shared.open(url)
-    }
-
     func sessionDidStartRequest(_ session: Session) {}
     func sessionDidFinishRequest(_ session: Session) {}
     func sessionDidStartFormSubmission(_ session: Session) {}

--- a/Source/Turbo/Session/SessionDelegate.swift
+++ b/Source/Turbo/Session/SessionDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WebKit
 
 public protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didProposeVisit proposal: VisitProposal)
@@ -7,6 +8,7 @@ public protocol SessionDelegate: AnyObject {
 
     func session(_ session: Session, openExternalURL url: URL)
     func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+    func session(_ session: Session, decidePolicyFor navigationAction: WKNavigationAction) -> WKNavigationActionPolicy
 
     func sessionDidLoadWebView(_ session: Session)
     func sessionDidStartRequest(_ session: Session)

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -10,7 +10,11 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         navigationController = TestableNavigationController()
         modalNavigationController = TestableNavigationController()
 
-        navigator = Navigator(session: session, modalSession: modalSession)
+        navigator = Navigator(
+            session: session,
+            modalSession: modalSession,
+            configuration: .init(name: "Test", startLocation: oneURL)
+        )
         hierarchyController = NavigationHierarchyController(delegate: navigator, navigationController: navigationController, modalNavigationController: modalNavigationController)
         navigator.hierarchyController = hierarchyController
 
@@ -308,8 +312,8 @@ final class NavigationHierarchyControllerTests: XCTestCase {
     }
 
     func test_externalURL_presentsSafariViewController() throws {
-        let externalURL = URL(string: "https://example.com")!
-        navigator.session(navigator.session, openExternalURL: externalURL)
+        let externalURL = URL(string: "https://external.com")!
+        navigator.route(externalURL)
 
         XCTAssert(navigationController.presentedViewController is SFSafariViewController)
         XCTAssertEqual(navigationController.presentedViewController?.modalPresentationStyle, .pageSheet)
@@ -317,7 +321,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
 
     func test_invalidExternalURL_doesNotPresentSafariViewController() throws {
         let externalURL = URL(string: "ftp://example.com")!
-        navigator.session(navigator.session, openExternalURL: externalURL)
+        navigator.route(externalURL)
 
         /// No assertions needed. App will crash if we pass a non-http or non-https scheme to SFSafariViewController.
     }

--- a/Tests/Turbo/Routing/AppNavigationRouteDecisionHandlerTest.swift
+++ b/Tests/Turbo/Routing/AppNavigationRouteDecisionHandlerTest.swift
@@ -1,0 +1,40 @@
+@testable import HotwireNative
+import WebKit
+import XCTest
+
+final class AppNavigationRouteDecisionHandlerTest: XCTestCase {
+    var route = AppNavigationRouteDecisionHandler()
+    let navigatorConfiguration = Navigator.Configuration(
+        name: "test",
+        startLocation: URL(string: "https://my.app.com")!
+    )
+
+    func test_matching_result_navigates() {
+        XCTAssertEqual(route.decision, Router.Decision.navigate)
+    }
+
+    func test_url_on_app_domain_matches() {
+        let url = URL(string: "https://my.app.com/page")!
+        let result = route.matches(location: url, configuration: navigatorConfiguration)
+
+        XCTAssertTrue(result)
+    }
+
+    func test_url_without_subdomain_does_not_match() {
+        let url = URL(string: "https://app.com/page")!
+        let result = route.matches(location: url, configuration: navigatorConfiguration)
+
+        XCTAssertFalse(result)
+    }
+
+    func test_masqueraded_url_does_not_match() {
+        let url = URL(string: "https://app.my.com@fake.domain")!
+        let result = route.matches(location: url, configuration: navigatorConfiguration)
+
+        XCTAssertFalse(result)
+    }
+
+    func test_matching_navigation_action_policy_cancels_web_navigation() {
+        XCTAssertEqual(route.navigationActionPolicy, WKNavigationActionPolicy.cancel)
+    }
+}

--- a/Tests/Turbo/Routing/BrowserRouteDecisionHandlerTest.swift
+++ b/Tests/Turbo/Routing/BrowserRouteDecisionHandlerTest.swift
@@ -1,0 +1,40 @@
+@testable import HotwireNative
+import WebKit
+import XCTest
+
+final class BrowserRouteDecisionHandlerTest: XCTestCase {
+    var route = BrowserRouteDecisionHandler()
+    let navigatorConfiguration = Navigator.Configuration(
+        name: "test",
+        startLocation: URL(string: "https://my.app.com")!
+    )
+
+    func test_matching_result_stops_navigation() {
+        XCTAssertEqual(route.decision, Router.Decision.cancel)
+    }
+
+    func test_url_on_external_domain_matches() {
+        let url = URL(string: "https://external.com/page")!
+        let result = route.matches(location: url, configuration: navigatorConfiguration)
+
+        XCTAssertTrue(result)
+    }
+
+    func test_url_without_subdomain_matches() {
+        let url = URL(string: "https://app.com/page")!
+        let result = route.matches(location: url, configuration: navigatorConfiguration)
+
+        XCTAssertTrue(result)
+    }
+
+    func test_url_on_app_domain_does_not_match() {
+        let url = URL(string: "https://my.app.com/page")!
+        let result = route.matches(location: url, configuration: navigatorConfiguration)
+
+        XCTAssertFalse(result)
+    }
+
+    func test_matching_navigation_action_policy_cancels_web_navigation() {
+        XCTAssertEqual(route.navigationActionPolicy, WKNavigationActionPolicy.cancel)
+    }
+}

--- a/Tests/Turbo/Test.swift
+++ b/Tests/Turbo/Test.swift
@@ -40,6 +40,9 @@ class TestVisitable: UIViewController, Visitable {
 }
 
 class TestSessionDelegate: NSObject, SessionDelegate {
+    func session(_ session: HotwireNative.Session, decidePolicyFor navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
+        .cancel
+    }
     var sessionDidLoadWebViewCalled = false { didSet { didChange?() }}
     var sessionDidStartRequestCalled = false
     var sessionDidFinishRequestCalled = false


### PR DESCRIPTION
This PR brings the concept of a Router and route decision handlers from Android (https://github.com/hotwired/hotwire-native-android/pull/12).

### **Routing**
Before performing an in-app navigation visit, the navigator routes the location URL through the app router. The router loops over each registered route decision handler until it finds a match (the order of the registered route decision handlers determines in what order they're processed). The matched route decision handler must return one of either:

`Router.Decision.navigate`: Informs the navigator to continue performing the in-app navigation visit.
`Router.Decision.cancel`: Informs the navigator to stop the in-app navigation visit. 

The matched route decision handler is given the opportunity to handle the visit by providing its own custom behaviour, such as opening an external browser.

### **Built-in route decision handlers**
There are two built-in route decision handlers that can be used by applications. 

1. **`AppNavigationRouteDecisionHandler`**: Allows location urls on the same domain as `Navigator.Configuration.startLocation` to navigate within the app.
2.  **`BrowserRouteDecisionHandler`**: Allows location urls on a different domain from `Navigator.Configuration.startLocation` to stop in-app navigation and route the URL to an external browser(see `ExternalURLOpeningOption`).

Both `AppNavigationRouteDecisionHandler` and `BrowserRouteDecisionHandler ` are registered by default. The route decision handlers that an application uses can be configured by calling `Hotwire.registerRouteDecisionHandlers([your decision handlers])`. 
Applications can create their own route decision handler implementations by implementing the `RouteDecisionHandler` protocol and registering them as described above.

### Changes

**External URLs**
External urls are now handled by the `BrowserRouteDecisionHandler`. The related old code was removed. Users can still specify how external links should open by setting one of the `ExternalURLOpeningOption` cases to the `HotwireConfig.defaultExternalURLOpeningOption`.

**Navigator Configuration**
The navigator must now be initialized with its configuration -`Navigator.Configuration`. This struct holds a navigator's name and its start location. It is passed to each route decision handler by the Router.