### PR TITLE
feat: add request completion to navigation delegate

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -222,11 +222,10 @@ extension Navigator: SessionDelegate {
 
     public func sessionDidFinishRequest(_ session: Session) {
         guard let url = session.activeVisitable?.visitableURL else { return }
-        
-        delegate.requestDidFinish(at: url)
 
         WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
             HTTPCookieStorage.shared.setCookies(cookies, for: url, mainDocumentURL: url)
+            self.delegate.requestDidFinish(at: url)
         }
     }
 

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -222,6 +222,8 @@ extension Navigator: SessionDelegate {
 
     public func sessionDidFinishRequest(_ session: Session) {
         guard let url = session.activeVisitable?.visitableURL else { return }
+        
+        delegate.requestDidFinish(at: url)
 
         WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
             HTTPCookieStorage.shared.setCookies(cookies, for: url, mainDocumentURL: url)

--- a/Source/Turbo/Navigator/NavigatorDelegate.swift
+++ b/Source/Turbo/Navigator/NavigatorDelegate.swift
@@ -33,6 +33,10 @@ public protocol NavigatorDelegate: AnyObject {
     /// Optional. Called after a form finishes a submission.
     /// If not implemented, no action is taken.
     func formSubmissionDidFinish(at url: URL)
+    
+    /// Optional. Called after a request.
+    /// If not implemented, no action is taken.
+    func requestDidFinish(at url: URL)
 }
 
 public extension NavigatorDelegate {
@@ -57,4 +61,6 @@ public extension NavigatorDelegate {
     func formSubmissionDidStart(to url: URL) {}
 
     func formSubmissionDidFinish(at url: URL) {}
+    
+    func requestDidFinish(at url: URL) {}
 }

--- a/Source/Turbo/Navigator/NavigatorDelegate.swift
+++ b/Source/Turbo/Navigator/NavigatorDelegate.swift
@@ -34,7 +34,7 @@ public protocol NavigatorDelegate: AnyObject {
     /// If not implemented, no action is taken.
     func formSubmissionDidFinish(at url: URL)
     
-    /// Optional. Called after a request.
+    /// Optional. Called after a request has completed.
     /// If not implemented, no action is taken.
     func requestDidFinish(at url: URL)
 }


### PR DESCRIPTION
### Description

This pull request introduces a change that allows us to track whenever a request is finished.

### Background

We initially extended the `HotwireWebViewController` and added a callback on the web side using `WKScriptMessageHandler`. However, we identified that this implementation could be simplified. By leveraging the `SessionDelegate#sessionDidFinishRequest` method, we can handle the event more efficiently.

### Changes

- Added a method `requestDidFinish` to the `NavigatorDelegate` that is called whenever `sessionDidFinishRequest` is fired.

### Testing

- Verified that the `requestDidFinish` method in `NavigatorDelegate` is called appropriately when `sessionDidFinishRequest` is fired.

### Additional Information

If you have any questions or need further clarification, please feel free to reach out.

Thank you for considering this pull request.