### PR TITLE
only update the navigation bar title when loading a page, not the tabs

### DIFF
--- a/Source/Turbo/Visitable/VisitableViewController.swift
+++ b/Source/Turbo/Visitable/VisitableViewController.swift
@@ -47,7 +47,7 @@ open class VisitableViewController: UIViewController, Visitable {
     // MARK: Visitable
 
     open func visitableDidRender() {
-        title = visitableView.webView?.title
+        navigationItem.title = visitableView.webView?.title
     }
 
     open func showVisitableActivityIndicator() {


### PR DESCRIPTION
context:

- https://github.com/hotwired/turbo-ios/pull/234
- https://discuss.hotwired.dev/t/hotwire-native-ios-prevent-tab-bar-items-from-having-their-title-changed-on-page-load/6284