### PR TITLE
Reflect current web view page location in `VisitableViewController`

### DIFF
--- a/Source/HotwireWebViewController.swift
+++ b/Source/HotwireWebViewController.swift
@@ -48,10 +48,12 @@ open class HotwireWebViewController: VisitableViewController, BridgeDestination 
     // MARK: Visitable
 
     override open func visitableDidActivateWebView(_ webView: WKWebView) {
+        super.visitableDidActivateWebView(webView)
         bridgeDelegate.webViewDidBecomeActive(webView)
     }
 
     override open func visitableDidDeactivateWebView() {
+        super.visitableDidDeactivateWebView()
         bridgeDelegate.webViewDidBecomeDeactivated()
     }
 

--- a/Source/HotwireWebViewController.swift
+++ b/Source/HotwireWebViewController.swift
@@ -5,7 +5,7 @@ import WebKit
 /// Use `Hotwire.registerBridgeComponents(_:)` to register bridge components.
 open class HotwireWebViewController: VisitableViewController, BridgeDestination {
     public lazy var bridgeDelegate = BridgeDelegate(
-        location: visitableURL.absoluteString,
+        location: initialVisitableURL.absoluteString,
         destination: self,
         componentTypes: Hotwire.bridgeComponentTypes
     )

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -146,7 +146,7 @@ class NavigationHierarchyController {
 
     private func visitingSamePage(on navigationController: UINavigationController, with controller: UIViewController, via url: URL) -> Bool {
         if let visitable = navigationController.topViewController as? Visitable {
-            return visitable.visitableURL == url
+            return visitable.initialVisitableURL == url
         } else if let topViewController = navigationController.topViewController {
             return topViewController.isMember(of: type(of: controller))
         }
@@ -158,7 +158,7 @@ class NavigationHierarchyController {
 
         let previousController = navigationController.viewControllers[navigationController.viewControllers.count - 2]
         if let previousVisitable = previousController as? VisitableViewController {
-            return previousVisitable.visitableURL == url
+            return previousVisitable.initialVisitableURL == url
         }
         return type(of: previousController) == type(of: controller)
     }

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -187,7 +187,7 @@ extension Navigator: SessionDelegate {
     }
 
     public func sessionDidStartFormSubmission(_ session: Session) {
-        if let url = session.topmostVisitable?.visitableURL {
+        if let url = session.topmostVisitable?.initialVisitableURL {
             delegate.formSubmissionDidStart(to: url)
         }
     }
@@ -196,7 +196,7 @@ extension Navigator: SessionDelegate {
         if session == modalSession {
             self.session.markSnapshotCacheAsStale()
         }
-        if let url = session.topmostVisitable?.visitableURL {
+        if let url = session.topmostVisitable?.initialVisitableURL {
             delegate.formSubmissionDidFinish(at: url)
         }
     }
@@ -221,7 +221,7 @@ extension Navigator: SessionDelegate {
     }
 
     public func sessionDidFinishRequest(_ session: Session) {
-        guard let url = session.activeVisitable?.visitableURL else { return }
+        guard let url = session.activeVisitable?.initialVisitableURL else { return }
 
         WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
             HTTPCookieStorage.shared.setCookies(cookies, for: url, mainDocumentURL: url)
@@ -312,7 +312,7 @@ extension Navigator {
             return
         }
 
-        guard let _ = session.topmostVisitable?.visitableURL else {
+        guard let _ = session.topmostVisitable?.initialVisitableURL else {
             return
         }
 
@@ -327,7 +327,7 @@ extension Navigator {
     /// - Parameter session: The session to recreate.
     private func recreateWebView(for session: Session) {
         guard let _ = session.activeVisitable?.visitableViewController,
-              let url = session.activeVisitable?.visitableURL else { return }
+              let url = session.activeVisitable?.initialVisitableURL else { return }
 
         let newSession = Session(webView: Hotwire.config.makeWebView())
         newSession.pathConfiguration = session.pathConfiguration

--- a/Source/Turbo/Session/Session.swift
+++ b/Source/Turbo/Session/Session.swift
@@ -55,10 +55,6 @@ public class Session: NSObject {
     }
 
     public func visit(_ visitable: Visitable, options: VisitOptions? = nil, reload: Bool = false) {
-        guard visitable.visitableURL != nil else {
-            fatalError("Visitable must provide a url!")
-        }
-
         visitable.visitableDelegate = self
 
         if reload {

--- a/Source/Turbo/Visit/Visit.swift
+++ b/Source/Turbo/Visit/Visit.swift
@@ -23,7 +23,7 @@ class Visit: NSObject {
 
     init(visitable: Visitable, options: VisitOptions, bridge: WebViewBridge) {
         self.visitable = visitable
-        self.location = visitable.visitableURL!
+        self.location = visitable.currentVisitableURL
         self.options = options
         self.bridge = bridge
         self.state = .initialized

--- a/Source/Turbo/Visitable/Visitable.swift
+++ b/Source/Turbo/Visitable/Visitable.swift
@@ -14,7 +14,7 @@ public protocol Visitable: AnyObject {
     var visitableViewController: UIViewController { get }
     var visitableDelegate: VisitableDelegate? { get set }
     var visitableView: VisitableView { get }
-    var visitableURL: URL { get }
+    var initialVisitableURL: URL { get }
     var currentVisitableURL: URL { get }
 
     func visitableDidRender()

--- a/Source/Turbo/Visitable/Visitable.swift
+++ b/Source/Turbo/Visitable/Visitable.swift
@@ -14,13 +14,15 @@ public protocol Visitable: AnyObject {
     var visitableViewController: UIViewController { get }
     var visitableDelegate: VisitableDelegate? { get set }
     var visitableView: VisitableView! { get }
-    var visitableURL: URL! { get }
+    var visitableURL: URL { get }
+    var currentVisitableURL: URL { get }
 
     func visitableDidRender()
     func showVisitableActivityIndicator()
     func hideVisitableActivityIndicator()
 
     func visitableDidActivateWebView(_ webView: WKWebView)
+    func visitableWillDeactivateWebView()
     func visitableDidDeactivateWebView()
 }
 
@@ -51,6 +53,7 @@ extension Visitable {
     }
 
     func deactivateVisitableWebView() {
+        visitableWillDeactivateWebView()
         visitableView.deactivateWebView()
         visitableDidDeactivateWebView()
     }

--- a/Source/Turbo/Visitable/Visitable.swift
+++ b/Source/Turbo/Visitable/Visitable.swift
@@ -13,7 +13,7 @@ public protocol VisitableDelegate: AnyObject {
 public protocol Visitable: AnyObject {
     var visitableViewController: UIViewController { get }
     var visitableDelegate: VisitableDelegate? { get set }
-    var visitableView: VisitableView! { get }
+    var visitableView: VisitableView { get }
     var visitableURL: URL { get }
     var currentVisitableURL: URL { get }
 

--- a/Source/Turbo/Visitable/VisitableViewController.swift
+++ b/Source/Turbo/Visitable/VisitableViewController.swift
@@ -5,13 +5,13 @@ open class VisitableViewController: UIViewController, Visitable {
     open weak var visitableDelegate: VisitableDelegate?
     open var appearReason: AppearReason = .pushedOntoNavigationStack
     open var disappearReason: DisappearReason = .poppedFromNavigationStack
-    public let visitableURL: URL
+    public let initialVisitableURL: URL
     public var currentVisitableURL: URL {
         resolveVisitableLocation()
     }
 
     public init(url: URL) {
-        visitableURL = url
+        initialVisitableURL = url
         visitableLocationState = .initialized(url)
         super.init(nibName: nil, bundle: nil)
     }
@@ -72,7 +72,7 @@ open class VisitableViewController: UIViewController, Visitable {
     }
 
     open func visitableWillDeactivateWebView() {
-        visitableLocationState = .deactivated(visitableView.webView?.url ?? visitableURL)
+        visitableLocationState = .deactivated(visitableView.webView?.url ?? initialVisitableURL)
     }
 
     open func visitableDidDeactivateWebView() {
@@ -109,7 +109,7 @@ open class VisitableViewController: UIViewController, Visitable {
     private func resolveVisitableLocation() -> URL {
         switch visitableLocationState {
         case .resolved:
-            return visitableView.webView?.url ?? visitableURL
+            return visitableView.webView?.url ?? initialVisitableURL
         case .initialized(let url):
             return url
         case .deactivated(let url):

--- a/Source/Turbo/Visitable/VisitableViewController.swift
+++ b/Source/Turbo/Visitable/VisitableViewController.swift
@@ -12,7 +12,7 @@ open class VisitableViewController: UIViewController, Visitable {
 
     public init(url: URL) {
         visitableURL = url
-        visitableLocationState = .unresolved(url)
+        visitableLocationState = .initialized(url)
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -82,7 +82,7 @@ open class VisitableViewController: UIViewController, Visitable {
     // MARK: Private
     enum VisitableLocationState {
         case resolved
-        case unresolved(URL)
+        case initialized(URL)
         case deactivated(URL)
     }
 
@@ -110,7 +110,7 @@ open class VisitableViewController: UIViewController, Visitable {
         switch visitableLocationState {
         case .resolved:
             return visitableView.webView?.url ?? visitableURL
-        case .unresolved(let url):
+        case .initialized(let url):
             return url
         case .deactivated(let url):
             return url

--- a/Source/Turbo/Visitable/VisitableViewController.swift
+++ b/Source/Turbo/Visitable/VisitableViewController.swift
@@ -90,7 +90,7 @@ open class VisitableViewController: UIViewController, Visitable {
 
     // MARK: Visitable View
 
-    open private(set) lazy var visitableView: VisitableView! = {
+    open private(set) lazy var visitableView: VisitableView = {
         let view = VisitableView(frame: CGRect.zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/Tests/Turbo/ColdBootVisitTests.swift
+++ b/Tests/Turbo/ColdBootVisitTests.swift
@@ -6,12 +6,16 @@ class ColdBootVisitTests: XCTestCase {
     private let webView = WKWebView()
     private let visitDelegate = TestVisitDelegate()
     private var visit: ColdBootVisit!
+    private var visitable: TestVisitable!
+    let url = URL(string: "http://localhost/")!
 
     override func setUp() {
-        let url = URL(string: "http://localhost/")!
-        let bridge = WebViewBridge(webView: webView)
 
-        visit = ColdBootVisit(visitable: TestVisitable(url: url), options: VisitOptions(), bridge: bridge)
+        let bridge = WebViewBridge(webView: webView)
+        visitable = TestVisitable(url: url)
+        visitable.currentVisitableURL = URL(string: "http://localhost/new")!
+
+        visit = ColdBootVisit(visitable: visitable, options: VisitOptions(), bridge: bridge)
         visit.delegate = visitDelegate
     }
 
@@ -48,5 +52,11 @@ class ColdBootVisitTests: XCTestCase {
         visitDelegate.methodsCalled.remove("visitDidStart(_:)")
         visit.start()
         XCTAssertFalse(visitDelegate.didCall("visitDidStart(_:)"))
+    }
+
+    func test_visit_takesTheCurrentVisitableURL() {
+        visit.start()
+        XCTAssertTrue(visitDelegate.visitDidStartWasCalled)
+        XCTAssertEqual(URL(string: "http://localhost/new")!, visitDelegate.visitDidStartVisit?.location)
     }
 }

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -95,7 +95,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         navigator.route(proposal)
         
         let visitable = navigator.session.activeVisitable as! VisitableViewController
-        XCTAssertEqual(visitable.visitableURL, oneURL)
+        XCTAssertEqual(visitable.initialVisitableURL, oneURL)
         XCTAssertEqual(navigator.rootViewController.viewControllers.count, 1)
     }
     
@@ -115,7 +115,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         navigator.route(proposal)
         
         let visitable = navigator.modalSession.activeVisitable as! VisitableViewController
-        XCTAssertEqual(visitable.visitableURL, oneURL)
+        XCTAssertEqual(visitable.initialVisitableURL, oneURL)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
     }
     
@@ -132,7 +132,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         navigator.route(proposal)
         
         let visitable = navigator.session.activeVisitable as! VisitableViewController
-        XCTAssertEqual(visitable.visitableURL, oneURL)
+        XCTAssertEqual(visitable.initialVisitableURL, oneURL)
         
         XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigator.rootViewController.viewControllers.count, 1)
@@ -334,7 +334,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
 
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssert(navigationController.topViewController == topViewController)
-        XCTAssertNotEqual(navigator.session.activeVisitable?.visitableURL, proposal.url)
+        XCTAssertNotEqual(navigator.session.activeVisitable?.initialVisitableURL, proposal.url)
     }
 
     func test_externalURL_presentsSafariViewController() throws {
@@ -443,9 +443,9 @@ final class NavigationHierarchyControllerTests: XCTestCase {
     private func assertVisited(url: URL, on context: Context) {
         switch context {
         case .main:
-            XCTAssertEqual(navigator.session.activeVisitable?.visitableURL, url)
+            XCTAssertEqual(navigator.session.activeVisitable?.initialVisitableURL, url)
         case .modal:
-            XCTAssertEqual(navigator.modalSession.activeVisitable?.visitableURL, url)
+            XCTAssertEqual(navigator.modalSession.activeVisitable?.initialVisitableURL, url)
         }
     }
 }

--- a/Tests/Turbo/Test.swift
+++ b/Tests/Turbo/Test.swift
@@ -14,11 +14,11 @@ class TestVisitable: UIViewController, Visitable {
 
     var visitableDelegate: VisitableDelegate?
     var visitableView: VisitableView
-    var visitableURL: URL
+    var initialVisitableURL: URL
     var currentVisitableURL: URL
 
     init(url: URL) {
-        self.visitableURL = url
+        self.initialVisitableURL = url
         self.visitableView = VisitableView(frame: .zero)
         self.currentVisitableURL = url
         super.init(nibName: nil, bundle: nil)

--- a/Tests/Turbo/Test.swift
+++ b/Tests/Turbo/Test.swift
@@ -8,16 +8,19 @@ class TestVisitable: UIViewController, Visitable {
     var visitableDidRenderCalled = false
     var visitableDidActivateWebViewWasCalled = false
     var visitableDidDeactivateWebViewWasCalled = false
+    var visitableWillDeactivateWebViewWasCalled = false
 
     // MARK: - Visitable
 
     var visitableDelegate: VisitableDelegate?
     var visitableView: VisitableView!
-    var visitableURL: URL!
+    var visitableURL: URL
+    var currentVisitableURL: URL
 
     init(url: URL) {
         self.visitableURL = url
         self.visitableView = VisitableView(frame: .zero)
+        self.currentVisitableURL = url
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -28,6 +31,10 @@ class TestVisitable: UIViewController, Visitable {
 
     func visitableDidRender() {
         visitableDidRenderCalled = true
+    }
+
+    func visitableWillDeactivateWebView() {
+        visitableWillDeactivateWebViewWasCalled = true
     }
 
     func visitableDidActivateWebView(_ webView: WKWebView) {
@@ -86,6 +93,8 @@ class TestSessionDelegate: NSObject, SessionDelegate {
 
 class TestVisitDelegate {
     var methodsCalled: Set<String> = []
+    var visitDidStartWasCalled = false
+    var visitDidStartVisit: Visit?
 
     func didCall(_ method: String) -> Bool {
         methodsCalled.contains(method)
@@ -107,6 +116,8 @@ extension TestVisitDelegate: VisitDelegate {
 
     func visitDidStart(_ visit: Visit) {
         record()
+        visitDidStartWasCalled = true
+        visitDidStartVisit = visit
     }
 
     func visitDidComplete(_ visit: Visit) {

--- a/Tests/Turbo/Test.swift
+++ b/Tests/Turbo/Test.swift
@@ -13,7 +13,7 @@ class TestVisitable: UIViewController, Visitable {
     // MARK: - Visitable
 
     var visitableDelegate: VisitableDelegate?
-    var visitableView: VisitableView!
+    var visitableView: VisitableView
     var visitableURL: URL
     var currentVisitableURL: URL
 

--- a/Tests/Turbo/VisitableViewControllerTests.swift
+++ b/Tests/Turbo/VisitableViewControllerTests.swift
@@ -1,0 +1,58 @@
+@testable import HotwireNative
+import WebKit
+import XCTest
+
+class VisitableViewControllerTests: XCTestCase {
+    var viewController: VisitableViewController!
+    var webView: WebViewSpy!
+    let originalURL = URL(string: "https://example.com")!
+
+    override func setUp() {
+        webView = WebViewSpy(frame: .zero)
+        webView.overriddenURL = originalURL
+        viewController = VisitableViewController(url: originalURL)
+    }
+
+    func test_visitableURL_and_currentURL_match_on_init() {
+        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.currentVisitableURL, originalURL)
+    }
+
+    func test_currentURL_matches_new_webview_url_on_webView_activated_and_rendered() {
+        viewController.visitableView.activateWebView(webView, forVisitable: viewController)
+        viewController.visitableDidRender()
+
+        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.currentVisitableURL, originalURL)
+
+        let overriddenURL = URL(string: "https://example.com?tab=a")!
+        webView.overriddenURL = overriddenURL
+
+        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.currentVisitableURL, overriddenURL)
+    }
+
+    func test_currentURL_matches_new_webview_url_on_webView_deactivation() {
+        viewController.visitableView.activateWebView(webView, forVisitable: viewController)
+        viewController.visitableDidRender()
+
+        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.currentVisitableURL, originalURL)
+
+        let overriddenURL = URL(string: "https://example.com?tab=a")!
+        webView.overriddenURL = overriddenURL
+        viewController.visitableWillDeactivateWebView()
+        viewController.visitableDidDeactivateWebView()
+
+        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.currentVisitableURL, overriddenURL)
+    }
+}
+
+final class WebViewSpy: WKWebView {
+    var overriddenURL: URL?
+
+    override var url: URL? {
+        overriddenURL
+    }
+}

--- a/Tests/Turbo/VisitableViewControllerTests.swift
+++ b/Tests/Turbo/VisitableViewControllerTests.swift
@@ -14,7 +14,7 @@ class VisitableViewControllerTests: XCTestCase {
     }
 
     func test_visitableURL_and_currentURL_match_on_init() {
-        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.initialVisitableURL, originalURL)
         XCTAssertEqual(viewController.currentVisitableURL, originalURL)
     }
 
@@ -22,13 +22,13 @@ class VisitableViewControllerTests: XCTestCase {
         viewController.visitableView.activateWebView(webView, forVisitable: viewController)
         viewController.visitableDidRender()
 
-        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.initialVisitableURL, originalURL)
         XCTAssertEqual(viewController.currentVisitableURL, originalURL)
 
         let overriddenURL = URL(string: "https://example.com?tab=a")!
         webView.overriddenURL = overriddenURL
 
-        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.initialVisitableURL, originalURL)
         XCTAssertEqual(viewController.currentVisitableURL, overriddenURL)
     }
 
@@ -36,7 +36,7 @@ class VisitableViewControllerTests: XCTestCase {
         viewController.visitableView.activateWebView(webView, forVisitable: viewController)
         viewController.visitableDidRender()
 
-        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.initialVisitableURL, originalURL)
         XCTAssertEqual(viewController.currentVisitableURL, originalURL)
 
         let overriddenURL = URL(string: "https://example.com?tab=a")!
@@ -44,7 +44,7 @@ class VisitableViewControllerTests: XCTestCase {
         viewController.visitableWillDeactivateWebView()
         viewController.visitableDidDeactivateWebView()
 
-        XCTAssertEqual(viewController.visitableURL, originalURL)
+        XCTAssertEqual(viewController.initialVisitableURL, originalURL)
         XCTAssertEqual(viewController.currentVisitableURL, overriddenURL)
     }
 }


### PR DESCRIPTION
This PR adapts the `VisitableViewController` to reflect the current web view page location and matches the reload behaviour with Android.

**Context**
Rails/Hotwire allows a page location change(via redirect or Turbo Frames) without a new visit proposal.
Since the native view controller (`VisitableViewController`) is created with the original URL this change is never reflected (see https://github.com/hotwired/hotwire-native-ios/pull/77).

**Changes**
- `VisitableViewController ` now exposes a `currentVisitableURL` which reflects the associated web view's URL.
- `Visit` uses the `currentVisitableURL` when initialized.

NOTE: The backstack handling hasn't changed. It still relies on the `VisitableViewController`'s  original URL-`visitableURL`.

**Resolving web view's URL**
The `currentVisitableURL` is derived by leveraging an internal `VisitableLocationState` - an enum with three cases:
	•	`resolved`: Indicates that the page has finished loading. In this state, `currentVisitableURL` returns the URL from the web view if available, or falls back to the original `visitableURL`.
	•	`unresolved(URL)`: Represents the initial state before the page has been loaded. Here, the provided original URL is returned.
	•	`deactivated(URL)`: Captures the state when the web view has been deactivated. In this case, the stored URL is used as the current location.

The `resolveVisitableLocation()` function uses these states to determine the correct URL for `currentVisitableURL`. This mechanism ensures that the view controller consistently reflects the current web view's URL throughout its lifecycle, whether it’s still loading, fully loaded, or deactivated.