### PR TITLE
Add internal parameter name to new function

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -33,7 +33,7 @@ extension SceneController: UIWindowSceneDelegate {
 }
 
 extension SceneController: NavigatorDelegate {
-    func handle(proposal: VisitProposal) -> ProposalResult {
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
         switch proposal.viewController {
         case NumbersViewController.pathConfigurationIdentifier:
             return .acceptCustom(NumbersViewController(url: proposal.url, navigator: navigator))

--- a/Source/NavigationHandler.swift
+++ b/Source/NavigationHandler.swift
@@ -3,8 +3,8 @@ import Foundation
 /// A protocol to bridge back to Hotwire world from a native context. Use this
 /// to trigger a new page visit including routing and presentation.
 ///
-/// When responding to `NavigatorDelegate.handle(proposal:)`, to route
-/// a native view controller, pass in an instance of `Navigator` typed
+/// When responding to `NavigatorDelegate.handle(proposal:navigator:)`, to
+/// route a native view controller, pass in an instance of `Navigator` typed
 /// as this protocol with an unowned reference. This ensures you avoid a
 /// circular dependency between the two.
 ///

--- a/Source/Turbo/Navigator/Helpers/PathConfigurationIdentifiable.swift
+++ b/Source/Turbo/Navigator/Helpers/PathConfigurationIdentifiable.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Use a view controller's `pathConfigurationIdentifier` property instead of `proposal.url` when deciding how to handle a proposal.
 ///
 /// ```swift
-/// func handle(proposal: VisitProposal) -> ProposalResult {
+/// func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
 ///    switch proposal.viewController {
 ///    case RecipeViewController.pathConfigurationIdentifier:
 ///        return .acceptCustom(RecipeViewController())

--- a/Source/Turbo/Navigator/Helpers/ProposalResult.swift
+++ b/Source/Turbo/Navigator/Helpers/ProposalResult.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// Return from `NavigatorDelegate.handle(proposal:)` to route a custom controller.
+/// Return from `NavigatorDelegate.handle(proposal:from:)` to route a custom controller.
 public enum ProposalResult: Equatable {
     /// Route a `VisitableViewController`.
     case accept

--- a/Source/Turbo/Navigator/NavigatorDelegate.swift
+++ b/Source/Turbo/Navigator/NavigatorDelegate.swift
@@ -14,7 +14,7 @@ public protocol NavigatorDelegate: AnyObject {
     /// - Parameter proposal: `VisitProposal` navigation destination
     /// - Parameter from: the `Navigator` receiving the proposal
     /// - Returns:`ProposalResult` - how to react to the visit proposal
-    func handle(proposal: VisitProposal, from: Navigator) -> ProposalResult
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult
 
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
@@ -39,7 +39,7 @@ public protocol NavigatorDelegate: AnyObject {
 }
 
 public extension NavigatorDelegate {
-    func handle(proposal: VisitProposal, from: Navigator) -> ProposalResult {
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
         .accept
     }
 

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -486,7 +486,7 @@ extension VisitProposal {
 // MARK: - AlertControllerDelegate
 
 private class AlertControllerDelegate: NavigatorDelegate {
-    func handle(proposal: VisitProposal, from: Navigator) -> ProposalResult {
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
         if proposal.url.path == "/alert" {
             return .acceptCustom(UIAlertController(title: "Alert", message: nil, preferredStyle: .alert))
         }


### PR DESCRIPTION
This adds an internal parameter name to the new "handle" function signature. I think this makes it a bit easier to understand when implementing the delegate function.