### PR TITLE
Notify bridge destination when a component is initialized

### DIFF
--- a/Source/Bridge/BridgeDelegate.swift
+++ b/Source/Bridge/BridgeDelegate.swift
@@ -1,7 +1,13 @@
 import Foundation
 import WebKit
 
-public protocol BridgeDestination: AnyObject {}
+public protocol BridgeDestination: AnyObject {
+    func onBridgeComponentInitialized(_ component: BridgeComponent)
+}
+
+public extension BridgeDestination {
+    func onBridgeComponentInitialized(_ component: BridgeComponent) {}
+}
 
 @MainActor
 public protocol BridgingDelegate: AnyObject {
@@ -162,7 +168,8 @@ public final class BridgeDelegate: BridgingDelegate {
         
         let component = componentType.init(destination: destination, delegate: self)
         initializedComponents[name] = component
-        
+        destination.onBridgeComponentInitialized(component)
+
         return component
     }
 }

--- a/Tests/Bridge/BridgeDelegate+DestinationTests.swift
+++ b/Tests/Bridge/BridgeDelegate+DestinationTests.swift
@@ -81,4 +81,20 @@ class BridgeDelegateDestinationTests: XCTestCase {
         let component: BridgeComponentSpy? = delegate.component()
         XCTAssertNil(component)
     }
+
+    func testBridgeDestinationIsNotifiedWhenComponentIsInitialized() {
+        delegate.onViewDidLoad()
+        delegate.bridgeDidReceiveMessage(.test)
+
+        XCTAssertTrue(destination.onBridgeComponentInitializedWasCalled)
+        XCTAssertTrue(destination.initializedBridgeComponent is BridgeComponentSpy)
+
+        destination.onBridgeComponentInitializedWasCalled = false
+        destination.initializedBridgeComponent = nil
+
+        delegate.bridgeDidReceiveMessage(.test)
+
+        XCTAssertFalse(destination.onBridgeComponentInitializedWasCalled)
+        XCTAssertNil(destination.initializedBridgeComponent)
+    }
 }

--- a/Tests/Bridge/TestData.swift
+++ b/Tests/Bridge/TestData.swift
@@ -1,7 +1,15 @@
 import Foundation
 @testable import HotwireNative
 
-final class AppBridgeDestination: BridgeDestination {}
+final class AppBridgeDestination: BridgeDestination {
+    var onBridgeComponentInitializedWasCalled = false
+    var initializedBridgeComponent: BridgeComponent?
+
+    func onBridgeComponentInitialized(_ component: BridgeComponent) {
+        onBridgeComponentInitializedWasCalled = true
+        initializedBridgeComponent = component
+    }
+}
 
 final class OneBridgeComponent: BridgeComponent {
     override static var name: String { "one" }


### PR DESCRIPTION
This PR adds a function to `BridgeDestination` to get notified when a component is initialized.