### PR TITLE
Update the web bridge reference to match hotwire-native-bridge `v1.2+`

### DIFF
--- a/Source/Bridge/bridge.js
+++ b/Source/Bridge/bridge.js
@@ -68,13 +68,13 @@
     }
 
     get isWebBridgeAvailable() {
-        // Fallback to Strada for legacy Strada web JavaScript.
-      return window.Bridge ?? window.Strada
+      // Fallback to Strada for legacy Strada web JavaScript.
+      return window.HotwireNative ?? window.Strada
     }
 
     get webBridge() {
       // Fallback to Strada for legacy Strada web JavaScript.
-      return window.Bridge?.web ?? window.Strada.web
+      return window.HotwireNative?.web ?? window.Strada.web
     }
   }
 


### PR DESCRIPTION
This updates the web bridge global to prefer `window.HotwireNative` over `window.Strada`. The corresponding change was made in: **hotwire-native-bridge** `1.2`:

- PR: https://github.com/hotwired/hotwire-native-bridge/pull/7
- Release: https://github.com/hotwired/hotwire-native-bridge/releases/tag/v1.2.0