### PR TITLE
Update the web bridge reference to match hotwire-native-bridge v1.2+

### DIFF
--- a/Source/Bridge/bridge.js
+++ b/Source/Bridge/bridge.js
@@ -68,13 +68,13 @@
     }
 
     get isWebBridgeAvailable() {
-        // Fallback to Strada for legacy Strada web JavaScript.
-      return window.Bridge ?? window.Strada
+      // Fallback to Strada for legacy Strada web JavaScript.
+      return window.HotwireNative ?? window.Strada
     }
 
     get webBridge() {
       // Fallback to Strada for legacy Strada web JavaScript.
-      return window.Bridge?.web ?? window.Strada.web
+      return window.HotwireNative?.web ?? window.Strada.web
     }
   }
 


### PR DESCRIPTION
This PR updates the web bridge global to prefer `window.HotwireNative` over `window.Strada`.
See the corresponding [Android PR](https://github.com/hotwired/hotwire-native-android/pull/130) for more info.