### PR TITLE
Use `weak` instead of `unowned` references for delegates

### DIFF
--- a/Demo/Bridge/FormComponent.swift
+++ b/Demo/Bridge/FormComponent.swift
@@ -26,7 +26,7 @@ final class FormComponent: BridgeComponent {
 
     private weak var submitBarButtonItem: UIBarButtonItem?
     private var viewController: UIViewController? {
-        delegate.destination as? UIViewController
+        delegate?.destination as? UIViewController
     }
 
     private func handleConnectEvent(message: Message) {

--- a/Demo/Bridge/MenuComponent.swift
+++ b/Demo/Bridge/MenuComponent.swift
@@ -21,7 +21,7 @@ final class MenuComponent: BridgeComponent {
     // MARK: Private
 
     private var viewController: UIViewController? {
-        delegate.destination as? UIViewController
+        delegate?.destination as? UIViewController
     }
 
     private func handleDisplayEvent(message: Message) {

--- a/Demo/Bridge/OverflowMenuComponent.swift
+++ b/Demo/Bridge/OverflowMenuComponent.swift
@@ -21,7 +21,7 @@ final class OverflowMenuComponent: BridgeComponent {
     // MARK: Private
 
     private var viewController: UIViewController? {
-        delegate.destination as? UIViewController
+        delegate?.destination as? UIViewController
     }
 
     private func handleConnectEvent(message: Message) {

--- a/Demo/NumbersViewController.swift
+++ b/Demo/NumbersViewController.swift
@@ -6,12 +6,16 @@ import UIKit
 final class NumbersViewController: UITableViewController, PathConfigurationIdentifiable {
     static var pathConfigurationIdentifier: String { "numbers" }
 
-    convenience init(url: URL, navigator: NavigationHandler) {
-        self.init(nibName: nil, bundle: nil)
+    init(url: URL, navigator: NavigationHandler) {
         self.url = url
         self.navigator = navigator
+        super.init(nibName: nil, bundle: nil)
     }
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     private var url: URL
     private weak var navigator: NavigationHandler?
 

--- a/Demo/NumbersViewController.swift
+++ b/Demo/NumbersViewController.swift
@@ -12,8 +12,8 @@ final class NumbersViewController: UITableViewController, PathConfigurationIdent
         self.navigator = navigator
     }
 
-    private var url: URL!
-    private unowned var navigator: NavigationHandler?
+    private var url: URL
+    private weak var navigator: NavigationHandler?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Source/Bridge/BridgeComponent.swift
+++ b/Source/Bridge/BridgeComponent.swift
@@ -60,7 +60,8 @@ open class BridgeComponent: BridgingComponent {
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
     public func reply(with message: Message) async throws -> Bool {
         guard let delegate else {
-            throw BridgeComponentError.delegateNil
+            logger.warning("bridgeMessageFailedToReply: delegate is nil")
+            return false
         }
 
         return try await delegate.reply(with: message)
@@ -75,6 +76,7 @@ open class BridgeComponent: BridgingComponent {
     public func reply(with message: Message, completion: ReplyCompletionHandler? = nil) {
         Task {
             guard let delegate else {
+                logger.warning("bridgeMessageFailedToReply: delegate is nil")
                 completion?(.failure(BridgeComponentError.delegateNil))
                 return
             }

--- a/Source/Bridge/BridgeComponent.swift
+++ b/Source/Bridge/BridgeComponent.swift
@@ -3,8 +3,8 @@ import Foundation
 @MainActor
 protocol BridgingComponent: AnyObject {
     static var name: String { get }
-    var delegate: BridgingDelegate { get }
-    
+    var delegate: BridgingDelegate? { get }
+
     init(destination: BridgeDestination,
          delegate: BridgingDelegate)
     
@@ -23,6 +23,10 @@ protocol BridgingComponent: AnyObject {
     func viewDidDisappear()
 }
 
+public enum BridgeComponentError: Error {
+    case delegateNil
+}
+
 @MainActor
 open class BridgeComponent: BridgingComponent {
     public typealias ReplyCompletionHandler = (Result<Bool, Error>) -> Void
@@ -36,8 +40,8 @@ open class BridgeComponent: BridgingComponent {
         fatalError("BridgeComponent subclass must provide a unique 'name'")
     }
     
-    public unowned let delegate: BridgingDelegate
-    
+    public weak var delegate: BridgingDelegate?
+
     public required init(destination: BridgeDestination, delegate: BridgingDelegate) {
         self.delegate = delegate
     }
@@ -55,7 +59,11 @@ open class BridgeComponent: BridgingComponent {
     /// - Parameter message: The message to be replied with.
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
     public func reply(with message: Message) async throws -> Bool {
-        try await delegate.reply(with: message)
+        guard let delegate else {
+            throw BridgeComponentError.delegateNil
+        }
+
+        return try await delegate.reply(with: message)
     }
 
     /// Replies to the web with a received message, optionally replacing its `event` or `jsonData`.
@@ -66,6 +74,11 @@ open class BridgeComponent: BridgingComponent {
     ///                   It includes a result indicating whether the reply was successful or not.
     public func reply(with message: Message, completion: ReplyCompletionHandler? = nil) {
         Task {
+            guard let delegate else {
+                completion?(.failure(BridgeComponentError.delegateNil))
+                return
+            }
+
             do {
                 let result = try await delegate.reply(with: message)
                 completion?(.success(result))

--- a/Source/Bridge/BridgeDelegate.swift
+++ b/Source/Bridge/BridgeDelegate.swift
@@ -12,7 +12,7 @@ public extension BridgeDestination {
 @MainActor
 public protocol BridgingDelegate: AnyObject {
     var location: String { get }
-    var destination: BridgeDestination { get }
+    var destination: BridgeDestination? { get }
     var webView: WKWebView? { get }
     
     func webViewDidBecomeActive(_ webView: WKWebView)
@@ -34,7 +34,7 @@ public protocol BridgingDelegate: AnyObject {
 @MainActor
 public final class BridgeDelegate: BridgingDelegate {
     public let location: String
-    public unowned let destination: BridgeDestination
+    public weak var destination: BridgeDestination?
     public var webView: WKWebView? {
         bridge?.webView
     }
@@ -165,7 +165,12 @@ public final class BridgeDelegate: BridgingDelegate {
         guard let componentType = componentTypes.first(where: { $0.name == name }) else {
             return nil
         }
-        
+
+        guard let destination else {
+            logger.warning("bridgeDidFailToInitializeComponent: destination is nil")
+            return nil
+        }
+
         let component = componentType.init(destination: destination, delegate: self)
         initializedComponents[name] = component
         destination.onBridgeComponentInitialized(component)

--- a/Source/NavigationHandler.swift
+++ b/Source/NavigationHandler.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 /// When responding to `NavigatorDelegate.handle(proposal:navigator:)`, to
 /// route a native view controller, pass in an instance of `Navigator` typed
-/// as this protocol with an unowned reference. This ensures you avoid a
+/// as this protocol with a weak reference. This ensures you avoid a
 /// circular dependency between the two.
 ///
 /// - Note: See `NumbersViewController` in the demo app for an example.

--- a/Source/Turbo/Navigator/WKUIController.swift
+++ b/Source/Turbo/Navigator/WKUIController.swift
@@ -6,7 +6,7 @@ public protocol WKUIControllerDelegate: AnyObject {
 }
 
 open class WKUIController: NSObject, WKUIDelegate {
-    private unowned var delegate: WKUIControllerDelegate
+    private weak var delegate: WKUIControllerDelegate?
 
     public init(delegate: WKUIControllerDelegate!) {
         self.delegate = delegate
@@ -17,7 +17,7 @@ open class WKUIController: NSObject, WKUIDelegate {
         alert.addAction(UIAlertAction(title: "Close", style: .default) { _ in
             completionHandler()
         })
-        delegate.present(alert, animated: true)
+        delegate?.present(alert, animated: true)
     }
 
     open func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
@@ -28,6 +28,6 @@ open class WKUIController: NSObject, WKUIDelegate {
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
             completionHandler(false)
         })
-        delegate.present(alert, animated: true)
+        delegate?.present(alert, animated: true)
     }
 }

--- a/Tests/Bridge/BridgeComponentAsyncAPITests.swift
+++ b/Tests/Bridge/BridgeComponentAsyncAPITests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import HotwireNative
+import WebKit
+import XCTest
+
+@MainActor
+class BridgeComponentAsyncAPITests: XCTestCase {
+    private var delegate: BridgeDelegateSpy!
+    private var destination: AppBridgeDestination!
+    private var component: OneBridgeComponent!
+    private let message = Message(id: "1",
+                                  component: OneBridgeComponent.name,
+                                  event: "connect",
+                                  metadata: .init(url: "https://37signals.com"),
+                                  jsonData: "{\"title\":\"Page-title\",\"subtitle\":\"Page-subtitle\"}")
+
+    override func setUp() async throws {
+        destination = AppBridgeDestination()
+        delegate = BridgeDelegateSpy()
+        component = OneBridgeComponent(destination: destination, delegate: delegate)
+        component.didReceive(message: message)
+    }
+
+    func test_didReceiveCachesTheMessage() {
+        let cachedMessage = component.receivedMessage(for: "connect")
+        XCTAssertEqual(cachedMessage, message)
+    }
+
+    func test_replyWithNilDelegateReturnsFalse() async throws {
+        component.delegate = nil
+        let success = try await component.reply(to: "connect")
+
+        XCTAssertFalse(success)
+    }
+
+    func test_replyToReceivedMessageSucceeds() async throws {
+        let success = try await component.reply(to: "connect")
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(delegate.replyWithMessageWasCalled)
+        XCTAssertEqual(delegate.replyWithMessageArg, message)
+    }
+
+    func test_replyToReceivedMessageWithACodableObjectSucceeds() async throws {
+        let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
+        let newJsonData = "{\"title\":\"hey\",\"subtitle\":\"\",\"actionName\":\"tap\"}"
+        let newMessage = message.replacing(jsonData: newJsonData)
+
+        let success = try await component.reply(to: "connect", with: messageData)
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(delegate.replyWithMessageWasCalled)
+        XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
+    }
+
+    func test_replyToMessageNotReceivedWithACodableObjectIgnoresTheReply() async throws {
+        let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
+
+        let success = try await component.reply(to: "disconnect", with: messageData)
+
+        XCTAssertFalse(success)
+        XCTAssertFalse(delegate.replyWithMessageWasCalled)
+        XCTAssertNil(delegate.replyWithMessageArg)
+    }
+
+    func test_replyToMessageNotReceivedIgnoresTheReply() async throws {
+        let success = try await component.reply(to: "disconnect")
+
+        XCTAssertFalse(success)
+        XCTAssertFalse(delegate.replyWithMessageWasCalled)
+        XCTAssertNil(delegate.replyWithMessageArg)
+    }
+
+    func test_replyToMessageNotReceivedWithJsonDataIgnoresTheReply() async throws {
+        let success = try await component.reply(to: "disconnect", with: "{\"title\":\"Page-title\"}")
+
+        XCTAssertFalse(success)
+        XCTAssertFalse(delegate.replyWithMessageWasCalled)
+        XCTAssertNil(delegate.replyWithMessageArg)
+    }
+
+    func test_replyWithSucceedsWhenBridgeIsSet() async throws {
+        let newJsonData = "{\"title\":\"Page-title\"}"
+        let newMessage = message.replacing(jsonData: newJsonData)
+
+        let success = try await component.reply(with: newMessage)
+
+        XCTAssertTrue(success)
+        XCTAssertTrue(delegate.replyWithMessageWasCalled)
+        XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
+    }
+}

--- a/Tests/Bridge/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Bridge/Spies/BridgeDelegateSpy.swift
@@ -4,7 +4,7 @@ import WebKit
 
 final class BridgeDelegateSpy: BridgingDelegate {
     let location: String = ""
-    let destination: BridgeDestination = AppBridgeDestination()
+    let destination: BridgeDestination? = AppBridgeDestination()
     var webView: WKWebView? = nil
     
     var replyWithMessageWasCalled = false

--- a/Tests/Turbo/Navigator/NavigationDelegateTests.swift
+++ b/Tests/Turbo/Navigator/NavigationDelegateTests.swift
@@ -7,7 +7,7 @@ final class NavigationDelegateTests: Navigator {
         let url = URL(string: "https://example.com")!
 
         let proposal = VisitProposal(url: url, options: VisitOptions())
-        let result = delegate.handle(proposal: proposal, from: self)
+        let result = delegate?.handle(proposal: proposal, from: self)
 
         XCTAssertEqual(result, .accept)
     }


### PR DESCRIPTION
This PR refactors the code by using `weak` instead of `unowned` references for delegates.

**Context**
Using `unowned` assumes that the referenced object will always exist, which may not be the case. If the referenced object is accessed after it has been deallocated, the app crashes.

The most common source of crashes is within `BridgeComponent`s due to their unpredictable lifecycles. By using a weak reference instead, we avoid this crash and throw and error.

