### PR TITLE
Restore support for running demo app on iOS 15 and later

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Load the path configuration
         Hotwire.loadPathConfiguration(from: [
             .file(Bundle.main.url(forResource: "path-configuration", withExtension: "json")!),
-            .server(Demo.current.appending(path: "configurations/ios_v1.json"))
+            .server(Demo.current.appendingPathComponent("configurations/ios_v1.json"))
         ])
 
         // Set an optional custom user agent application prefix.

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -255,7 +255,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -312,7 +312,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -335,6 +335,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -361,6 +362,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Demo/Tabs.swift
+++ b/Demo/Tabs.swift
@@ -24,19 +24,19 @@ extension HotwireTab {
 
     static let bridgeComponents = HotwireTab(
         title: "Bridge Components",
-        image: .init(systemName: "widget.small")!,
-        url: Demo.current.appending(path: "components")
+        image: .init(systemName: "square.grid.2x2")!,
+        url: Demo.current.appendingPathComponent("components")
     )
 
     static let resources = HotwireTab(
         title: "Resources",
-        image: .init(systemName: "questionmark.text.page")!,
-        url: Demo.current.appending(path: "resources")
+        image: .init(systemName: "book.closed")!,
+        url: Demo.current.appendingPathComponent("resources")
     )
 
     static let bugsAndFixes = HotwireTab(
         title: "Bugs & Fixes",
         image: .init(systemName: "ladybug")!,
-        url: Demo.current.appending(path: "bugs")
+        url: Demo.current.appendingPathComponent("bugs")
     )
 }


### PR DESCRIPTION
I regularly test my apps on older versions of iOS. While debugging, I attempted to run the demo app on iOS 15.8.3 and encountered a few issues.

Although Hotwire Native [requires iOS 14](https://github.com/hotwired/hotwire-native-ios/blob/main/Package.swift#L8) as its minimum deployment target, it seems that the current demo app does not run on any iOS version lower than 18.0.
This PR updates parts of the demo app to restore compatibility with lower iOS versions. I have tested it down to iOS 15.8.3.

One thing I'm not sure about is the tab icons:
The SF Symbols used for the tabs "widget.small" and "questionmark.text.page" are only available in iOS 18.0 or newer.
I replaced them with symbols that look similar and are available in iOS 14+.
Of course, you'll have to decide if this is acceptable to you or if you'd prefer to use different symbols.
|Before|After|
|---|---|
|![Screenshot 2025-04-28 at 20 48 12](https://github.com/user-attachments/assets/b5c27031-6f90-4fc2-bd19-9a47afb5f7e3)|![Screenshot 2025-04-28 at 20 53 35](https://github.com/user-attachments/assets/d3b248c0-0dfc-4276-9058-ba58ff35429b)|

Alternatively, we could stick with the original symbols and add a check for the iOS version:
```swift
static let bridgeComponents = HotwireTab(
    title: "Bridge Components",
    image: {
        if #available(iOS 18.0, *) {
            return UIImage(systemName: "widget.small")!
        } else {
            return UIImage(systemName: "square.grid.2x2")!
        }
    }(),
    url: Demo.current.appendingPathComponent("components")
)
```