### PR TITLE
Fix NavigationDelegateTests

### DIFF
--- a/Tests/Turbo/Navigator/NavigationDelegateTests.swift
+++ b/Tests/Turbo/Navigator/NavigationDelegateTests.swift
@@ -2,13 +2,42 @@
 import SafariServices
 import XCTest
 
-final class NavigationDelegateTests: Navigator {
+final class NavigationDelegateTests: XCTestCase {
+    override func setUp() async throws {
+        spyDelegate = NavigatorDelegateSpy()
+        navigator = Navigator(
+            session: session,
+            modalSession: modalSession,
+            delegate: spyDelegate,
+            configuration: .init(name: "test", startLocation: URL(string: "http://example.com")!),
+        )
+    }
+    
+    override func tearDown() async throws {
+        spyDelegate.handlerExecuted = false
+    }
+    
     func test_controllerForProposal_defaultsToVisitableViewController() throws {
-        let url = URL(string: "https://example.com")!
-
+        let url = URL(string: "http://example.com/testing")!
         let proposal = VisitProposal(url: url, options: VisitOptions())
-        let result = delegate?.handle(proposal: proposal, from: self)
+        
+        navigator.route(proposal)
 
-        XCTAssertEqual(result, .accept)
+        XCTAssertEqual(spyDelegate.handlerExecuted, true)
+    }
+    
+    private var navigator: Navigator!
+    private var spyDelegate: NavigatorDelegateSpy!
+    
+    private let session = Session(webView: Hotwire.config.makeWebView())
+    private let modalSession = Session(webView: Hotwire.config.makeWebView())
+    
+    class NavigatorDelegateSpy: NavigatorDelegate {
+        public var handlerExecuted = false
+        
+        func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
+            self.handlerExecuted = true
+            return .accept
+        }
     }
 }


### PR DESCRIPTION
While investigating this issue https://github.com/hotwired/hotwire-native-ios/issues/122#issuecomment-2845371427 I noticed that `NavigationDelegateTests` wasn't executing. It seems that this was happening because it was a subclass of `Navigator` rather than a subclass of `XCTestCase`. After changing that and setting up the required state the test is being executed and passing.