### PR TITLE
Fix Navigator delegate issues by using a strong reference?

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -8,7 +8,7 @@ class DefaultNavigatorDelegate: NSObject, NavigatorDelegate {}
 /// Handles navigation to new URLs using the following rules:
 /// [Navigator Handled Flows](https://native.hotwired.dev/reference/navigation)
 public class Navigator {
-    public weak var delegate: NavigatorDelegate?
+    public var delegate: NavigatorDelegate?
 
     public var rootViewController: UINavigationController { hierarchyController.navigationController }
     public var modalRootViewController: UINavigationController { hierarchyController.modalNavigationController }

--- a/Tests/Turbo/Navigator/NavigationDelegateTests.swift
+++ b/Tests/Turbo/Navigator/NavigationDelegateTests.swift
@@ -2,13 +2,42 @@
 import SafariServices
 import XCTest
 
-final class NavigationDelegateTests: Navigator {
+final class NavigationDelegateTests: XCTestCase {
+    override func setUp() async throws {
+        spyDelegate = NavigatorDelegateSpy()
+        navigator = Navigator(
+            session: session,
+            modalSession: modalSession,
+            delegate: spyDelegate,
+            configuration: .init(name: "test", startLocation: URL(string: "http://example.com")!),
+        )
+    }
+    
+    override func tearDown() async throws {
+        spyDelegate.handlerExecuted = false
+    }
+    
     func test_controllerForProposal_defaultsToVisitableViewController() throws {
-        let url = URL(string: "https://example.com")!
-
+        let url = URL(string: "http://example.com/testing")!
         let proposal = VisitProposal(url: url, options: VisitOptions())
-        let result = delegate?.handle(proposal: proposal, from: self)
+        
+        navigator.route(proposal)
 
-        XCTAssertEqual(result, .accept)
+        XCTAssertEqual(spyDelegate.handlerExecuted, true)
+    }
+    
+    private var navigator: Navigator!
+    private var spyDelegate: NavigatorDelegateSpy!
+    
+    private let session = Session(webView: Hotwire.config.makeWebView())
+    private let modalSession = Session(webView: Hotwire.config.makeWebView())
+    
+    class NavigatorDelegateSpy: NavigatorDelegate {
+        public var handlerExecuted = false
+        
+        func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
+            self.handlerExecuted = true
+            return .accept
+        }
     }
 }

--- a/Tests/Turbo/Navigator/NavigationDelegateTests.swift
+++ b/Tests/Turbo/Navigator/NavigationDelegateTests.swift
@@ -9,7 +9,7 @@ final class NavigationDelegateTests: XCTestCase {
             session: session,
             modalSession: modalSession,
             delegate: spyDelegate,
-            configuration: .init(name: "test", startLocation: URL(string: "http://example.com")!),
+            configuration: .init(name: "test", startLocation: URL(string: "http://example.com")!)
         )
     }
     


### PR DESCRIPTION
I'm having a similar issue as @carolinagalvan describes here: https://github.com/hotwired/hotwire-native-ios/issues/122#issue-3009073996. Updating to version 1.2.0 hasn't fixed the problem for me.

If I pass a delegate to the navigator the webview crashes with an `IdleExit` warning. When I change the `delegate` attribute in `Navigator` to a strong reference this issue goes away. I'm not certain of the broader implications of this change.

Device: iPhone 16
iOS Version: iOS 18.2

This code reproduces the issue in the demo app:
```swift
import HotwireNative
import UIKit

let rootURL = URL(string: "https://hotwire-native-demo.dev")!

class SceneDelegate: UIResponder, UIWindowSceneDelegate {

    var window: UIWindow?
    private let navigator = Navigator(
        configuration: Navigator.Configuration(name: "main", startLocation: rootURL),
        delegate: NavigationDelegate()
    )

    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        window?.rootViewController = navigator.rootViewController
        navigator.start()
    }
}

class NavigationDelegate: NavigatorDelegate {
    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
        debugPrint(proposal)
        return .accept
    }
}
```

#### IdleExit Warning

<img width="938" alt="Image" src="https://github.com/user-attachments/assets/43e1282a-8e07-4ce6-89bf-44e6bab4a9c2" />

#### Crashed WebView

<img width="508" alt="Image" src="https://github.com/user-attachments/assets/4442bb4c-ff7a-41ee-898a-09df6e958a22" />
