### PR TITLE
Automatically manage app lifecycle status

### DIFF
--- a/Source/Turbo/Utils/AppLifecycleObserver.swift
+++ b/Source/Turbo/Utils/AppLifecycleObserver.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UIKit
+
+protocol AppLifecycleObserverDelegate: AnyObject {
+    func appDidEnterBackground()
+    func appWillEnterForeground()
+}
+
+final class AppLifecycleObserver {
+    weak var delegate: AppLifecycleObserverDelegate?
+
+    var appState: UIApplication.State {
+        UIApplication.shared.applicationState
+    }
+
+    init(delegate: AppLifecycleObserverDelegate? = nil) {
+        self.delegate = delegate
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func appDidEnterBackground() {
+        delegate?.appDidEnterBackground()
+    }
+
+    @objc private func appWillEnterForeground() {
+        delegate?.appWillEnterForeground()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}


### PR DESCRIPTION
This PR replaces manual tracking of app lifecycle status with a dedicated `AppLifecycleObserver` to automatically manage and observe application state changes. This improves code maintainability and reduces potential errors.

**Breaking Changes**
- Removed manual app lifecycle tracking properties (`appInBackground`) and methods (`appDidBecomeActive`, `appDidEnterBackground`) from `Navigator`.

**Other Changes**

- Introduced `AppLifecycleObserver` as a property of `Navigator` to handle app lifecycle events.
- Implemented `AppLifecycleObserverDelegate` conformance on `Navigator` and refactor related code.
