### PR TITLE
Safely cast jsonData to InternalMessageData

### DIFF
--- a/Tests/Bridge/InternalMessageTests.swift
+++ b/Tests/Bridge/InternalMessageTests.swift
@@ -98,7 +98,63 @@ class InternalMessageTests: XCTestCase {
         XCTAssertEqual(message?.id, "1")
         XCTAssertEqual(message?.data, [:])
     }
-    
+
+    func testFromMessageWithArrayData() {
+        let arrayJsonData = """
+        ["item1", "item2", "item3"]
+        """
+
+        let message = Message(id: "1",
+                            component: "page",
+                            event: "connect",
+                            metadata: .init(url: "https://37signals.com"),
+                            jsonData: arrayJsonData)
+
+        let internalMessage = InternalMessage(from: message)
+
+        // Should default to empty dictionary when array data is provided
+        XCTAssertEqual(internalMessage.id, "1")
+        XCTAssertEqual(internalMessage.component, "page")
+        XCTAssertEqual(internalMessage.event, "connect")
+        XCTAssertEqual(internalMessage.data, [:])
+    }
+
+    func testFromJsonObjectWithArrayData() {
+        let jsonObjectWithArray: [String: AnyHashable] = [
+            "id": "1",
+            "component": "page",
+            "event": "connect",
+            "data": ["item1", "item2", "item3"]
+        ]
+
+        let internalMessage = InternalMessage(jsonObject: jsonObjectWithArray)
+
+        // Should default to empty dictionary when array data is provided
+        XCTAssertEqual(internalMessage?.id, "1")
+        XCTAssertEqual(internalMessage?.component, "page")
+        XCTAssertEqual(internalMessage?.event, "connect")
+        XCTAssertEqual(internalMessage?.data, [:])
+    }
+
+    func testFromMessageWithValidDictionaryData() {
+        let dictionaryJsonData = """
+        {"title": "Test Title", "count": 42}
+        """
+        let message = Message(id: "1",
+                            component: "page",
+                            event: "connect",
+                            metadata: .init(url: "https://37signals.com"),
+                            jsonData: dictionaryJsonData)
+
+        let internalMessage = InternalMessage(from: message)
+
+        XCTAssertEqual(internalMessage.id, "1")
+        XCTAssertEqual(internalMessage.component, "page")
+        XCTAssertEqual(internalMessage.event, "connect")
+        XCTAssertEqual(internalMessage.data["title"] as? String, "Test Title")
+        XCTAssertEqual(internalMessage.data["count"] as? Int, 42)
+    }
+
     private func createPage() -> PageData {
         return PageData(
             metadata: InternalMessage.Metadata(url: "https://37signals.com"),


### PR DESCRIPTION
This pull request logs a warning when a jsonObject is passed which does not conform to the InternalMessageData type, otherwise retaining the existing behaviour of defaulting to an empty object.

This assists users of the library who might pass a Codable object in as data, and then observe that the value they pass is dropped, without changing any other behaviour.

I personally ran into this attempting to pass an array of result objects in a message reply - because the `as?` conversion fails, the original data was silently dropped.

I'm not generally a Swift developer, so what I've produced might not be idiomatic. I had also hoped to add an assertion covering the logger message, but I couldn't find a way to capture log messages without reimplementing a logger. 