### PR TITLE
Pop presenting controller if redirected to modal

### DIFF
--- a/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
@@ -6,7 +6,7 @@ public extension VisitProposal {
     }
 
     var presentation: Navigation.Presentation {
-        options.action == .replace ? .replace : properties.presentation
+        properties.presentation
     }
 
     var modalStyle: Navigation.ModalStyle {

--- a/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
@@ -6,7 +6,7 @@ public extension VisitProposal {
     }
 
     var presentation: Navigation.Presentation {
-        properties.presentation
+        options.action == .replace ? .replace : properties.presentation
     }
 
     var modalStyle: Navigation.ModalStyle {

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -126,6 +126,10 @@ class NavigationHierarchyController {
                 modalNavigationController.setViewControllers([controller], animated: proposal.animated)
                 modalNavigationController.setModalPresentationStyle(via: proposal)
                 navigationController.present(modalNavigationController, animated: proposal.animated)
+
+                if proposal.options.response?.redirected == true {
+                    navigationController.popViewController(animated: false)
+                }
             }
         }
     }
@@ -188,10 +192,6 @@ class NavigationHierarchyController {
                 modalNavigationController.setViewControllers([controller], animated: false)
                 modalNavigationController.setModalPresentationStyle(via: proposal)
                 navigationController.present(modalNavigationController, animated: proposal.animated)
-
-                if proposal.presentation == .replace {
-                    navigationController.popViewController(animated: false)
-                }
             }
         }
     }

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -188,6 +188,10 @@ class NavigationHierarchyController {
                 modalNavigationController.setViewControllers([controller], animated: false)
                 modalNavigationController.setModalPresentationStyle(via: proposal)
                 navigationController.present(modalNavigationController, animated: proposal.animated)
+
+                if proposal.presentation == .replace {
+                    navigationController.popViewController(animated: false)
+                }
             }
         }
     }

--- a/Source/Turbo/Visit/VisitResponse.swift
+++ b/Source/Turbo/Visit/VisitResponse.swift
@@ -2,10 +2,12 @@ import Foundation
 
 public struct VisitResponse: Codable {
     public let statusCode: Int
+    public let redirected: Bool
     public let responseHTML: String?
 
-    public init(statusCode: Int, responseHTML: String? = nil) {
+    public init(statusCode: Int, redirected: Int = 0, responseHTML: String? = nil) {
         self.statusCode = statusCode
+        self.redirected = redirected == 1
         self.responseHTML = responseHTML
     }
 

--- a/Source/Turbo/Visit/VisitResponse.swift
+++ b/Source/Turbo/Visit/VisitResponse.swift
@@ -5,10 +5,11 @@ public struct VisitResponse: Codable {
     public let redirected: Bool
     public let responseHTML: String?
 
-    public init(statusCode: Int, redirected: Int = 0, responseHTML: String? = nil) {
-        self.statusCode = statusCode
-        self.redirected = redirected == 1
-        self.responseHTML = responseHTML
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.statusCode = try container.decode(Int.self, forKey: .statusCode)
+        self.redirected = try container.decodeIfPresent(Bool.self, forKey: .redirected) ?? false
+        self.responseHTML = try container.decodeIfPresent(String.self, forKey: .responseHTML)
     }
 
     public var isSuccessful: Bool {

--- a/Tests/Turbo/VisitOptionsTests.swift
+++ b/Tests/Turbo/VisitOptionsTests.swift
@@ -20,6 +20,15 @@ class VisitOptionsTests: XCTestCase {
         XCTAssertNil(options.response)
     }
 
+    func test_Decodable_redirected() throws {
+        let json = """
+        {"response": {"statusCode": 301, "redirected": true}}
+        """.data(using: .utf8)!
+
+        let options = try JSONDecoder().decode(VisitOptions.self, from: json)
+        XCTAssert(options.response?.redirected == true)
+    }
+
     func test_Decodable_canBeInitializedWithResponse() throws {
         _ = try validVisitVisitOptions(responseHTMLString: "<html></html>")
     }


### PR DESCRIPTION
This PR handles the issue described in #112.

Previously, when an endpoint redirected from a non-modal screen to a modal screen, the presenting view controller was left on the main stack. Empty.

This PR checks for the `.replace` navigation action and if it is the first modal screen on the stack, pops the underlying (redirected _from_) view controller on the main stack.

I tested a few use-cases here but I'm sure there are some flows that I missed. Any help finding these would be greatly appreciated!

Fixes #112 