### PR TITLE
Allow inline media playback

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -120,6 +120,7 @@ public struct HotwireConfig {
         configuration.defaultWebpagePreferences?.preferredContentMode = .mobile
         configuration.applicationNameForUserAgent = userAgent
         configuration.processPool = sharedProcessPool
+        configuration.allowsInlineMediaPlayback = true
         return configuration
     }
 }


### PR DESCRIPTION
I was running into [this issue](https://github.com/hotwired/hotwire-native-ios/discussions/153) where inline videos on my splash page were becoming full screen once they loaded. I found that we just need to update the webview configuration to allow inline media playback. Found the solution on https://stackoverflow.com/a/51161093/90551

Here's an example HTML snippet that you can put inside the hotwire native demo site to test the issue. Note that I have a `playsinline` attribute set, but it is not obeyed unless you update the WKWebviewConfiguration.allowsInlineMediaPlayback parameter.

```erb
  <div class="margin-bs-l margin-be-l" style="text-align: center;">
    <video width="360" height="203" autoplay muted loop playsinline style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
      <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
      <source src="https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_2mb.mp4" type="video/mp4">
      Your browser does not support the video tag.
    </video>
  </div>
```

Before: the video takes over the full screen once it loads and starts playing

https://github.com/user-attachments/assets/34915655-3c4a-4db0-8f91-7870f41df857

After: the video plays inline happily.

https://github.com/user-attachments/assets/b9fd3341-3f2d-4ffc-bde1-090116b81e45

As an aside, it would be very nice as a user of Hotwire Native to be able to change these configuration parameters without forking the library. But I haven't thought through how one might do that. This seems like a reasonable default though; I think it's pretty surprising to have what should be an inline video play fullscreen.