### PR TITLE
Lazy load tabs

### DIFF
--- a/Source/Turbo/ViewControllers/HotwireTabBarController.swift
+++ b/Source/Turbo/ViewControllers/HotwireTabBarController.swift
@@ -8,6 +8,7 @@ open class HotwireTabBarController: UITabBarController, NavigationHandler {
     public init(navigatorDelegate: NavigatorDelegate? = nil) {
         self.navigatorDelegate = navigatorDelegate
         super.init(nibName: nil, bundle: nil)
+        delegate = self
     }
 
     @available(*, unavailable)
@@ -40,8 +41,8 @@ open class HotwireTabBarController: UITabBarController, NavigationHandler {
         viewControllers = tabs.map {
             setupViewControllerForTab($0, navigatorDelegate: navigatorDelegate)
         }
-        navigatorsByTab.forEach { tab, navigator in
-            navigator.route(tab.url)
+        if let tab = hotwireTabs.first {
+            navigatorsByTab[tab]?.route(tab.url)
         }
     }
 
@@ -89,6 +90,15 @@ open class HotwireTabBarController: UITabBarController, NavigationHandler {
         navigatorsByTab[tab] = navigator
 
         return navigator.rootViewController
+    }
+}
+
+extension HotwireTabBarController: UITabBarControllerDelegate {
+    public func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard activeNavigator.rootViewController.viewControllers.isEmpty else { return }
+
+        let tab = hotwireTabs[selectedIndex]
+        activeNavigator.route(tab.url)
     }
 }
 


### PR DESCRIPTION
This PR changes the behavior of how tabs are loaded via `HotwireTabBarController`. Before, all tabs are loaded as soon as `load(_:)` is called. Now, only the first tab is loaded. The other tabs load only after navigating to that tab.

This change removes a [race condition for CSRF protection](#144) if root screens have `<form>` tags. It also reduces server load on app launch (only one request is made instead of up to five).