### PR TITLE
Configuration option to customize the error view

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 import WebKit
 
@@ -67,6 +68,11 @@ public struct HotwireConfig {
     /// Ensure you return a new instance each time.
     public var makeCustomWebView: WebViewBlock = { (configuration: WKWebViewConfiguration) in
         WKWebView.debugInspectable(configuration: configuration)
+    }
+
+    /// Optionally customize the native view presented when an error occurs.
+    public var makeCustomErrorView: (Error, ErrorPresenter.Handler?) -> AnyView = { error, handler in
+        AnyView(DefaultErrorView(error: error, handler: handler))
     }
 
     // MARK: Bridge


### PR DESCRIPTION
This PR addresses #100, allowing developers to customize the presented error screen with a custom SwiftUI view.

```swift
import SwiftUI

Hotwire.config.makeCustomErrorView = { error, handler in
    AnyView(MyErrorView(error: error, onRetry: handler))
}

struct MyErrorView: View {
    let error: Error
    let onRetry: ErrorPresenter.Handler?

    var body: some View {
        VStack(spacing: 12) {
            Text("Uh oh…").font(.title.bold())
            Text(error.localizedDescription).multilineTextAlignment(.center)
            if let onRetry {
                Button("Try again", action: onRetry)
            }
        }
        .padding()
    }
}
```