### PR TITLE
Configuration to hide the tab bar on push

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -22,6 +22,9 @@ public struct HotwireConfig {
     /// Sets the back button display mode of `HotwireWebViewController`.
     public var backButtonDisplayMode = UINavigationItem.BackButtonDisplayMode.default
 
+    /// Set to true to only show the tab bar on the root screens.
+    public var hidesTabBarWhenPushed = false
+
     /// Enable or disable debug logging for Turbo visits and bridge elements
     /// connecting, disconnecting, receiving/sending messages, and more.
     public var debugLoggingEnabled = false {

--- a/Source/Turbo/ViewControllers/HotwireNavigationController.swift
+++ b/Source/Turbo/ViewControllers/HotwireNavigationController.swift
@@ -35,6 +35,10 @@ open class HotwireNavigationController: UINavigationController {
             topVisitableViewController.disappearReason = .coveredByPush
         }
 
+        if Hotwire.config.hidesTabBarWhenPushed {
+            viewController.hidesBottomBarWhenPushed = (viewControllers.count >= 1)
+        }
+
         super.pushViewController(viewController, animated: animated)
     }
 
@@ -49,6 +53,16 @@ open class HotwireNavigationController: UINavigationController {
         }
 
         return poppedViewController
+    }
+
+    open override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
+        if Hotwire.config.hidesTabBarWhenPushed {
+            for (index, viewController) in viewControllers.enumerated() {
+                viewController.hidesBottomBarWhenPushed = (index != 0)
+            }
+        }
+
+        super.setViewControllers(viewControllers, animated: animated)
     }
 
     open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
```swift
Hotwire.config.hidesTabBarWhenPushed = true
```

When disabled (default behavior):

https://github.com/user-attachments/assets/6046a5be-750d-493b-980a-6048317cc974

When enabled:

https://github.com/user-attachments/assets/7ebde285-e05d-470f-81b0-9eab03fe61e4

Should fix #141.