### PR TITLE
Modal redirects feedback

### DIFF
--- a/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/VisitProposalExtension.swift
@@ -29,6 +29,10 @@ public extension VisitProposal {
         properties.animated
     }
 
+    var isRedirect: Bool {
+        options.response?.redirected == true
+    }
+
     internal var isHistoricalLocation: Bool {
         properties.historicalLocation
     }

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -126,10 +126,6 @@ class NavigationHierarchyController {
                 modalNavigationController.setViewControllers([controller], animated: proposal.animated)
                 modalNavigationController.setModalPresentationStyle(via: proposal)
                 navigationController.present(modalNavigationController, animated: proposal.animated)
-
-                if proposal.options.response?.redirected == true {
-                    navigationController.popViewController(animated: false)
-                }
             }
         }
     }

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -172,6 +172,9 @@ public class Navigator {
 
 extension Navigator: SessionDelegate {
     public func session(_ session: Session, didProposeVisit proposal: VisitProposal) {
+        if proposal.isRedirect {
+            pop(animated: false)
+        }
         route(proposal)
     }
 

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -173,7 +173,10 @@ public class Navigator {
 extension Navigator: SessionDelegate {
     public func session(_ session: Session, didProposeVisit proposal: VisitProposal) {
         if proposal.isRedirect {
-            pop(animated: false)
+            // Animate the pop only if we're in the active modal session
+            // and the visit is proposed on the default context.
+            let animatePop = session === modalSession && proposal.context == .default
+            pop(animated: animatePop)
         }
         route(proposal)
     }

--- a/Source/Turbo/Visit/VisitResponse.swift
+++ b/Source/Turbo/Visit/VisitResponse.swift
@@ -5,6 +5,12 @@ public struct VisitResponse: Codable {
     public let redirected: Bool
     public let responseHTML: String?
 
+    public init(statusCode: Int, redirected: Bool, responseHTML: String? = nil) {
+        self.statusCode = statusCode
+        self.redirected = redirected
+        self.responseHTML = responseHTML
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.statusCode = try container.decode(Int.self, forKey: .statusCode)


### PR DESCRIPTION
This is a feedback PR for https://github.com/hotwired/hotwire-native-ios/pull/154.

Changes

- Exposes `VisitResponse` initializer.
- Adds convenience `isRedirect` var to `VisitProposal` extension.
- Handles redirect in the same way as cross origin redirect is handled - popping the current destination from the backstack.