### PR TITLE
Configuration option to customize the error view - feedback

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -71,8 +71,8 @@ public struct HotwireConfig {
     }
 
     /// Optionally customize the native view presented when an error occurs.
-    public var makeCustomErrorView: (Error, ErrorPresenter.Handler?) -> AnyView = { error, handler in
-        AnyView(DefaultErrorView(error: error, handler: handler))
+    public var makeCustomErrorView: (Error, ErrorPresenter.Handler?) -> any ErrorPresentableView = { error, handler in
+        DefaultErrorView(error: error, handler: handler)
     }
 
     // MARK: Bridge

--- a/Source/Turbo/Navigator/Helpers/ErrorHandling/DefaultErrorView.swift
+++ b/Source/Turbo/Navigator/Helpers/ErrorHandling/DefaultErrorView.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftUI
+
+struct DefaultErrorView: ErrorPresentableView {
+    let error: Error
+    let handler: ErrorPresenter.Handler?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundColor(.accentColor)
+
+            Text("Error loading page")
+                .font(.largeTitle)
+
+            Text(error.localizedDescription)
+                .font(.body)
+                .multilineTextAlignment(.center)
+
+            if let handler {
+                Button("Retry") {
+                    handler()
+                }
+                .font(.system(size: 17, weight: .bold))
+            }
+        }
+        .padding(32)
+    }
+}
+
+private struct DefaultErrorView_Previews: PreviewProvider {
+    static var previews: some View {
+        return DefaultErrorView(error: NSError(
+            domain: "com.example.error",
+            code: 1001,
+            userInfo: [NSLocalizedDescriptionKey: "Could not connect to the server."]
+        )) {}
+    }
+}

--- a/Source/Turbo/Navigator/Helpers/ErrorHandling/ErrorPresentableView.swift
+++ b/Source/Turbo/Navigator/Helpers/ErrorHandling/ErrorPresentableView.swift
@@ -1,0 +1,7 @@
+import Foundation
+import SwiftUI
+
+public protocol ErrorPresentableView: View {
+    var error: Error { get }
+    var handler: ErrorPresenter.Handler? { get }
+}


### PR DESCRIPTION
This is a feedback PR for https://github.com/hotwired/hotwire-native-ios/pull/158.

**Changes**

- Introduced `ErrorPresentableView` protocol (no type erasure on the API level).
- Extracted `DefaultErrorView` in its own file.
- Minor fixes and naming tweaks.