### PR TITLE
Fix same page `restore` visits when returning to a web screen from a native screen

### DIFF
--- a/Source/Turbo/WebView/turbo.js
+++ b/Source/Turbo/WebView/turbo.js
@@ -40,7 +40,16 @@
 
     visitLocationWithOptionsAndRestorationIdentifier(location, options, restorationIdentifier) {
       if (window.Turbo) {
-        if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), options.action)) {
+        if (Turbo.navigator.location?.href === location && options.action === "restore") {
+          // A "restore" visit to the currently rendered location can occur when visiting
+          // a web -> native -> back to web screen. In this situation, the connect()
+          // callback (from Stimulus) in bridge component controllers will not be called,
+          // since they are already connected. We need to notify the web bridge library
+          // that a "restore" visit has occurred to manually trigger connect() and notify
+          // the native app so the native bridge component view state can be restored.
+          Turbo.navigator.startVisit(location, restorationIdentifier, options)
+          document.dispatchEvent(new Event("native:restore"))
+        } else if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), options.action)) {
           // Skip the same-page anchor scrolling behavior for visits initiated from the native
           // side. The page content may be stale and we want a fresh request from the network.
           Turbo.navigator.startVisit(location, restorationIdentifier, { "action": "replace" })


### PR DESCRIPTION
This is the iOS PR corresponding to the [Android one](https://github.com/hotwired/hotwire-native-android/pull/160).