### PR TITLE
Animate replace actions with a fade animation

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -41,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set configuration options
         Hotwire.config.backButtonDisplayMode = .minimal
         Hotwire.config.showDoneButtonOnModals = true
+        Hotwire.config.animateReplaceActions = true
 #if DEBUG
         Hotwire.config.debugLoggingEnabled = true
 #endif

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -22,7 +22,7 @@ public struct HotwireConfig {
     /// Sets the back button display mode of `HotwireWebViewController`.
     public var backButtonDisplayMode = UINavigationItem.BackButtonDisplayMode.default
 
-    /// Set to true to fade between content when replacing a screen.
+    /// Set to `true` to fade content when performing a `replace` visit.
     public var animateReplaceActions = false
 
     /// Enable or disable debug logging for Turbo visits and bridge elements

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -22,6 +22,9 @@ public struct HotwireConfig {
     /// Sets the back button display mode of `HotwireWebViewController`.
     public var backButtonDisplayMode = UINavigationItem.BackButtonDisplayMode.default
 
+    /// Set to true to fade between content when replacing a screen.
+    public var animateReplaceActions = false
+
     /// Enable or disable debug logging for Turbo visits and bridge elements
     /// connecting, disconnecting, receiving/sending messages, and more.
     public var debugLoggingEnabled = false {

--- a/Source/Turbo/Navigator/Extensions/UINavigationControllerExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/UINavigationControllerExtension.swift
@@ -3,10 +3,7 @@ import UIKit
 extension UINavigationController {
     func replaceLastViewController(with viewController: UIViewController) {
         if Hotwire.config.animateReplaceActions {
-            let transition = CATransition()
-            transition.type = .fade
-            transition.duration = 0.25
-            view.layer.add(transition, forKey: kCATransition)
+            addFadeTransition()
         }
 
         let viewControllers = viewControllers.dropLast()
@@ -31,5 +28,12 @@ extension UINavigationController {
         case .formSheet:
             modalPresentationStyle = .formSheet
         }
+    }
+
+    private func addFadeTransition() {
+        let transition = CATransition()
+        transition.type = .fade
+        transition.duration = 0.25
+        view.layer.add(transition, forKey: kCATransition)
     }
 }

--- a/Source/Turbo/Navigator/Extensions/UINavigationControllerExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/UINavigationControllerExtension.swift
@@ -33,7 +33,7 @@ extension UINavigationController {
     private func addFadeTransition() {
         let transition = CATransition()
         transition.type = .fade
-        transition.duration = 0.25
+        transition.duration = CATransaction.animationDuration()
         view.layer.add(transition, forKey: kCATransition)
     }
 }

--- a/Source/Turbo/Navigator/Extensions/UINavigationControllerExtension.swift
+++ b/Source/Turbo/Navigator/Extensions/UINavigationControllerExtension.swift
@@ -2,6 +2,13 @@ import UIKit
 
 extension UINavigationController {
     func replaceLastViewController(with viewController: UIViewController) {
+        if Hotwire.config.animateReplaceActions {
+            let transition = CATransition()
+            transition.type = .fade
+            transition.duration = 0.25
+            view.layer.add(transition, forKey: kCATransition)
+        }
+
         let viewControllers = viewControllers.dropLast()
         setViewControllers(viewControllers + [viewController], animated: false)
     }


### PR DESCRIPTION
This PR animates `replace` actions with a subtle fade animation. It is disabled by default and can be enabled with the following configuration option:

```swift
Hotwire.config.animateReplaceActions = true
```

### Default behavior 

https://github.com/user-attachments/assets/5448a328-0f48-4f5e-a9a9-d22a299487d4

### After enabling animations

https://github.com/user-attachments/assets/6a7d1693-6e59-4c45-a114-fef5cd1b3911

Closes #162.

---

I tested through the demo app and the only way this triggers is via the flow shown in the videos above. I couldn't find any other side effects, but would love to know if folks can identify any.