### PR TITLE
Bring back the authentication flow

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -12,7 +12,10 @@ final class SceneController: UIResponder {
     // MARK: - Authentication
 
     private func promptForAuthentication() {
-        let authURL = rootURL.appendingPathComponent("/signin")
+        // Clean up empty screen from 401 response.
+        tabBarController.activeNavigator.pop(animated: false)
+
+        let authURL = rootURL.appendingPathComponent("/session/new")
         tabBarController.activeNavigator.route(authURL)
     }
 }


### PR DESCRIPTION
This PR works with [#69 on the demo app](https://github.com/hotwired/hotwire-native-demo/pull/69) to reimplement the authentication flow.

The only real change is popping a controller off of the stack before presenting the `/session/new` route. Most of the code is in the other PR.


https://github.com/user-attachments/assets/c6ea1423-66b0-4108-8fc0-31ae665afb3a

