### PR TITLE
Descriptive errors

### DIFF
--- a/Source/Turbo/Networking/RedirectHandler.swift
+++ b/Source/Turbo/Networking/RedirectHandler.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum RedirectHandlerError: Error {
+public enum RedirectHandlerError: LocalizedError {
     case requestFailed(Error)
     case responseValidationFailed(reason: ResponseValidationFailureReason)
 
@@ -9,6 +9,22 @@ enum RedirectHandlerError: Error {
         case missingURL
         case invalidResponse
         case unacceptableStatusCode(code: Int)
+    }
+    
+    public var errorDescription: String? {
+        switch self {
+        case .requestFailed(let error):
+            return "Redirect resolution failed: \(error.localizedDescription)"
+        case .responseValidationFailed(let reason):
+            switch reason {
+            case .missingURL:
+                return "Redirect resolution failed: missing URL"
+            case .invalidResponse:
+                return "Redirect resolution response invalid"
+            case .unacceptableStatusCode(let code):
+                return "Redirect resolution failed \(code)"
+            }
+        }
     }
 }
 

--- a/Source/Turbo/Session/Session.swift
+++ b/Source/Turbo/Session/Session.swift
@@ -378,18 +378,21 @@ extension Session: WebViewDelegate {
     ///   - webView: The web view bridge.
     ///   - location: The original visit location requested.
     ///   - identifier: A unique identifier for the visit.
-    func webView(_ webView: WebViewBridge, didFailRequestWithNonHttpStatusToLocation location: URL, identifier: String) {
+    func webView(_ webView: WebViewBridge, didFailRequestWithNonHttpStatusToLocation location: URL, identifier: String, statusCode: Int) {
         log("didFailRequestWithNonHttpStatusToLocation",
-            ["location": location,
-             "visitIdentifier": identifier]
+            [
+                "location": location,
+                "visitIdentifier": identifier,
+                "statusCode": statusCode
+            ]
         )
 
         Task {
-            await resolveRedirect(to: location, identifier: identifier)
+            await resolveRedirect(to: location, identifier: identifier, statusCode: statusCode)
         }
     }
 
-    private func resolveRedirect(to location: URL, identifier: String) async {
+    private func resolveRedirect(to location: URL, identifier: String, statusCode: Int) async {
         do {
             let result = try await RedirectHandler().resolve(location: location)
             switch result {
@@ -399,7 +402,7 @@ extension Session: WebViewDelegate {
                      "visitIdentifier": identifier]
                 )
                 await failCurrentVisit(
-                    with: TurboError.http(statusCode: 0),
+                    with: TurboError(statusCode: statusCode),
                     visitIdentifier: identifier
                 )
             case .sameOriginRedirect(let url):
@@ -411,7 +414,7 @@ extension Session: WebViewDelegate {
                      "visitIdentifier": identifier]
                 )
                 await failCurrentVisit(
-                    with: TurboError.http(statusCode: 0),
+                    with: TurboError(statusCode: statusCode),
                     visitIdentifier: identifier
                 )
             case .crossOriginRedirect(let url):

--- a/Source/Turbo/Visit/ColdBootVisit.swift
+++ b/Source/Turbo/Visit/ColdBootVisit.swift
@@ -112,7 +112,8 @@ extension ColdBootVisit: WKNavigationDelegate {
                 decisionHandler(.allow)
             } else {
                 decisionHandler(.cancel)
-                fail(with: TurboError.http(statusCode: 0))
+                logger.error("Content mismatch detected: \(navigationResponse).")
+                fail(with: TurboError.contentTypeMismatch)
             }
         }
     }

--- a/Source/Turbo/WebView/ScriptMessage.swift
+++ b/Source/Turbo/WebView/ScriptMessage.swift
@@ -30,6 +30,10 @@ struct ScriptMessage {
         guard let options = data["options"] as? [String: Any] else { return nil }
         return VisitOptions(json: options)
     }
+    
+    var statusCode: Int? {
+        data["statusCode"] as? Int
+    }
 }
 
 extension ScriptMessage {

--- a/Source/Turbo/WebView/WebViewBridge.swift
+++ b/Source/Turbo/WebView/WebViewBridge.swift
@@ -7,7 +7,7 @@ protocol WebViewDelegate: AnyObject {
     func webView(_ webView: WebViewBridge, didFinishFormSubmissionToLocation location: URL)
     func webView(_ webView: WebViewBridge, didFailInitialPageLoadWithError: Error)
     func webView(_ webView: WebViewBridge, didFailJavaScriptEvaluationWithError error: Error)
-    func webView(_ webView: WebViewBridge, didFailRequestWithNonHttpStatusToLocation location: URL, identifier: String)
+    func webView(_ webView: WebViewBridge, didFailRequestWithNonHttpStatusToLocation location: URL, identifier: String, statusCode: Int)
 }
 
 protocol WebViewPageLoadDelegate: AnyObject {
@@ -123,7 +123,7 @@ extension WebViewBridge: ScriptMessageHandlerDelegate {
         case .visitProposed:
             delegate?.webView(self, didProposeVisitToLocation: message.location!, options: message.options!)
         case .visitRequestFailedWithNonHttpStatusCode:
-            delegate?.webView(self, didFailRequestWithNonHttpStatusToLocation: message.location!, identifier: message.identifier!)
+            delegate?.webView(self, didFailRequestWithNonHttpStatusToLocation: message.location!, identifier: message.identifier!, statusCode: message.statusCode!)
         case .visitProposalScrollingToAnchor:
             break
         case .visitProposalRefreshingPage:
@@ -135,7 +135,7 @@ extension WebViewBridge: ScriptMessageHandlerDelegate {
         case .visitRequestCompleted:
             visitDelegate?.webView(self, didCompleteRequestForVisitWithIdentifier: message.identifier!)
         case .visitRequestFailed:
-            visitDelegate?.webView(self, didFailRequestForVisitWithIdentifier: message.identifier!, statusCode: message.data["statusCode"] as! Int)
+            visitDelegate?.webView(self, didFailRequestForVisitWithIdentifier: message.identifier!, statusCode: message.statusCode!)
         case .visitRequestFinished:
             visitDelegate?.webView(self, didFinishRequestForVisitWithIdentifier: message.identifier!, date: message.date)
         case .visitRendered:

--- a/Source/Turbo/WebView/turbo.js
+++ b/Source/Turbo/WebView/turbo.js
@@ -149,7 +149,7 @@
       // the native side to determine whether a cross-origin redirect visit should
       // be proposed.
       if (statusCode <= 0) {
-        this.postMessage("visitRequestFailedWithNonHttpStatusCode", { location: location, identifier: visit.identifier })
+        this.postMessage("visitRequestFailedWithNonHttpStatusCode", { location: location, identifier: visit.identifier, statusCode: statusCode })
       } else {
         this.postMessage("visitRequestFailed", { location: location, identifier: visit.identifier, statusCode: statusCode })
       }


### PR DESCRIPTION
Three changes to increase the descriptiveness and accuracy of some HotwireNative errors:

- conforms `RedirectHandlerError` to `LocalizedError` so we can pass on an exact description of the underlying error to the client
-  ensures that we use the precise status code passed from the server when a redirect failed, instead of always assuming a `0` status code. 
- fail with a `contentTypeMismatch` error (instead of status code `0`) if the the url response is neither http nor a blob