### PR TITLE
Delete cookies before syncing them from WebView to HTTPCookieStorage

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -229,6 +229,11 @@ extension Navigator: SessionDelegate {
         guard let url = session.activeVisitable?.initialVisitableURL else { return }
 
         Task { @MainActor in
+            // To ensure deletions in the WebView are mirrored, first remove any shared cookies
+            // for this URL, then set the cookies read from WKWebView.
+            let storage = HTTPCookieStorage.shared
+            (storage.cookies(for: url) ?? []).forEach { storage.deleteCookie($0) }
+
             let cookies = await WKWebsiteDataStore.default().httpCookieStore.allCookies()
             HTTPCookieStorage.shared.setCookies(cookies, for: url, mainDocumentURL: url)
             delegate?.requestDidFinish(at: url)


### PR DESCRIPTION
This PR deletes cookies before syncing them from the WebView session to HTTPCookieStorage. Otherwise, when cookies are deleted on the WebView side of things, they may never get deleted from HTTPCookieStorage, which can lead to unexpected behavior.

I ran into an issue with our app where we were using URLSession.shared to make a request to log in to the app, and then copying cookies from HTTPCookieStorage to the WebView. On log out, we delete cookies relevant to the previously logged in user, and this does delete them from the WebView. But when we log back in to a different user account, the cookies from the previous user get restored. I looked around and it _seems_ like deleted cookies in the WebView never get deleted from HTTPCookieStorage, though I don't know for sure if my understanding is correct. But I was able to solve it in my app by deleting all cookies on logout. But I think it makes most sense to fix it here, upstream, so that this issue doesn't bite other people. It seems like the logically correct thing to do to ensure that cookies are always in sync with what the WebView session has.