### PR TITLE
Allow universal links to open in app within SafariViewController

### DIFF
--- a/Source/Turbo/Navigator/Routing/Handlers/SafariViewControllerRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/Handlers/SafariViewControllerRouteDecisionHandler.swift
@@ -4,11 +4,8 @@ import SafariServices
 /// Opens external URLs via an embedded `SafariViewController` so the user stays in-app.
 public final class SafariViewControllerRouteDecisionHandler: RouteDecisionHandler {
     public let name: String = "safari"
-    private var openUniversalLinksInApp: Bool
 
-    public init(openUniversalLinksInApp: Bool = false) {
-        self.openUniversalLinksInApp = openUniversalLinksInApp
-    }
+    public init() {}
 
     public func matches(location: URL,
                         configuration: Navigator.Configuration) -> Bool
@@ -29,22 +26,19 @@ public final class SafariViewControllerRouteDecisionHandler: RouteDecisionHandle
                        configuration _: Navigator.Configuration,
                        navigator: Navigator) -> Router.Decision
     {
-        let openModal = { self.open(externalURL: location, viewController: navigator.activeNavigationController) }
-
-        if openUniversalLinksInApp {
-            UIApplication.shared.open(location, options: [.universalLinksOnly: true]) { success in
-                if !success { openModal() }
+        // Try to open the link as an 'universal link' first (which opens the native app if present),
+        // else fall back to opening in a model.
+        UIApplication.shared.open(location, options: [.universalLinksOnly: true]) { success in
+            if !success {
+                self.open(externalURL: location, viewController: navigator.activeNavigationController)
             }
-        } else {
-            openModal()
         }
 
         return .cancel
     }
 
     func open(externalURL: URL,
-              viewController: UIViewController)
-    {
+              viewController: UIViewController) {
         let safariViewController = SFSafariViewController(url: externalURL)
         safariViewController.modalPresentationStyle = .pageSheet
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
This adds a config setting to `SafariViewControllerRouteDecisionHandler` to allow 'universal links' to be opened in their respective apps, but when not possible it will fall back to the modal.

---

[Universal links](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content/) are very nice to offer a seamless integration with apps. If you have the app installed it will open directly in the app, else it will just open a browser window.

This works out of the box if you only use system navigation handler. The down side is that all external links will now open in the system browser, meaning users leave your app for 'normal' web sites as well.

I considered some possible implementations:

1) Just always do it, technically this is a breaking change though, and maybe not something everyone wants.
2) A global config setting (through `Hotwire.config`). This does not require you to re-register the decision handlers, but seems a bit much when it's only used in one place and we can have it more locally to the class.
3) The current implementation, but `true` by default. Technically still a breaking change, but we can tell people to disable it if they want in the release notes / upgrade guide.
4) This current implementation, which defaults to `false`.

I feel this is the path of least resistance with regards to backwards compatability, but will probably leave some apps left out as you have to explicitly re-register the handlers like so:

```swift
  Hotwire.registerRouteDecisionHandlers([
      AppNavigationRouteDecisionHandler(),
      SafariViewControllerRouteDecisionHandler(openUniversalLinksInApp: true),
      SystemNavigationRouteDecisionHandler()
  ])
```

Happy to change the PR to any of these, i'm not sure what level of 'breaking change' you are comfortable with 😊

## Demonstration video:

For this I added an extra item to the demo app, an universal link for apple maps as that's installed in the simulator by default.

```erb
<%= render "navigations/item",
  path: "http://maps.apple.com/?saddr=San+Jose&daddr=San+Francisco&dirflg=r",
  icon: "external-link-bold",
  name: "External universal link (iOS)",
  description: "Visit a page with an universal link." %>
```

<table>
<tr>
 <td>Disabled (default, same as current)</td>
 <td>Enabled</td>
</tr>
<tr>
 <td>

https://github.com/user-attachments/assets/6a1ff1ea-0383-43d4-a1ff-07bb0e14a526

</td>
 <td>

https://github.com/user-attachments/assets/b4ac0544-4c02-4d12-a6de-3fcd2c25b1c0

</td>
</tr>
</table>

I also [wrote a blog post](https://paagman.dev/deep-link-hotwire-native-universal-links/) about how to integrate this which uses the techniques from this PR, but I think it's nice enough to be part of the framework!