### PR TITLE
Renames `Hotwire.config.hidesTabBarWhenPushed`

### DIFF
--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -24,7 +24,7 @@ public struct HotwireConfig {
     public var backButtonDisplayMode = UINavigationItem.BackButtonDisplayMode.default
 
     /// Set to true to only show the tab bar on the root screens.
-    public var hidesTabBarWhenPushed = false
+    public var hideTabBarWhenPushed = false
 
     /// Set to `true` to fade content when performing a `replace` visit.
     public var animateReplaceActions = false

--- a/Source/Turbo/ViewControllers/HotwireNavigationController.swift
+++ b/Source/Turbo/ViewControllers/HotwireNavigationController.swift
@@ -35,7 +35,7 @@ open class HotwireNavigationController: UINavigationController {
             topVisitableViewController.disappearReason = .coveredByPush
         }
 
-        if Hotwire.config.hidesTabBarWhenPushed {
+        if Hotwire.config.hideTabBarWhenPushed {
             viewController.hidesBottomBarWhenPushed = (viewControllers.count >= 1)
         }
 
@@ -56,7 +56,7 @@ open class HotwireNavigationController: UINavigationController {
     }
 
     open override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
-        if Hotwire.config.hidesTabBarWhenPushed {
+        if Hotwire.config.hideTabBarWhenPushed {
             for (index, viewController) in viewControllers.enumerated() {
                 viewController.hidesBottomBarWhenPushed = (index != 0)
             }


### PR DESCRIPTION
Renames `Hotwire.config.`hidesTabBarWhenPushed` to `hideTabBarWhenPushed` (no `s`) to better match naming of other configuration options.