### PR TITLE
Allow universal links to open in app within SafariViewController - feedback

### DIFF
--- a/Source/Turbo/Navigator/Routing/Handlers/SafariViewControllerRouteDecisionHandler.swift
+++ b/Source/Turbo/Navigator/Routing/Handlers/SafariViewControllerRouteDecisionHandler.swift
@@ -4,11 +4,8 @@ import SafariServices
 /// Opens external URLs via an embedded `SafariViewController` so the user stays in-app.
 public final class SafariViewControllerRouteDecisionHandler: RouteDecisionHandler {
     public let name: String = "safari"
-    private var openUniversalLinksInApp: Bool
 
-    public init(openUniversalLinksInApp: Bool = false) {
-        self.openUniversalLinksInApp = openUniversalLinksInApp
-    }
+    public init() {}
 
     public func matches(location: URL,
                         configuration: Navigator.Configuration) -> Bool
@@ -29,22 +26,19 @@ public final class SafariViewControllerRouteDecisionHandler: RouteDecisionHandle
                        configuration _: Navigator.Configuration,
                        navigator: Navigator) -> Router.Decision
     {
-        let openModal = { self.open(externalURL: location, viewController: navigator.activeNavigationController) }
-
-        if openUniversalLinksInApp {
-            UIApplication.shared.open(location, options: [.universalLinksOnly: true]) { success in
-                if !success { openModal() }
+        // Try to open the link as an 'universal link' first (which opens the native app if present),
+        // else fall back to opening in a model.
+        UIApplication.shared.open(location, options: [.universalLinksOnly: true]) { success in
+            if !success {
+                self.open(externalURL: location, viewController: navigator.activeNavigationController)
             }
-        } else {
-            openModal()
         }
 
         return .cancel
     }
 
     func open(externalURL: URL,
-              viewController: UIViewController)
-    {
+              viewController: UIViewController) {
         let safariViewController = SFSafariViewController(url: externalURL)
         safariViewController.modalPresentationStyle = .pageSheet
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
This PR improves https://github.com/hotwired/hotwire-native-ios/pull/191 by opening universal links via the active `UIWindowScene` instead of `UIApplication.shared.open`.