### PR TITLE
Position menu (action sheet) on element that triggered it

### DIFF
--- a/Demo/Bridge/MenuComponent.swift
+++ b/Demo/Bridge/MenuComponent.swift
@@ -1,6 +1,7 @@
 import Foundation
 import HotwireNative
 import UIKit
+import WebKit
 
 /// Bridge component to display a native bottom sheet menu,
 /// which will send the selected index of the tapped menu item back to the web.
@@ -26,10 +27,10 @@ final class MenuComponent: BridgeComponent {
 
     private func handleDisplayEvent(message: Message) {
         guard let data: MessageData = message.data() else { return }
-        showAlertSheet(with: data.title, items: data.items)
+        showAlertSheet(with: data.title, items: data.items, source: data.source)
     }
 
-    private func showAlertSheet(with title: String, items: [Item]) {
+    private func showAlertSheet(with title: String, items: [Item], source: Source) {
         let alertController = UIAlertController(
             title: title,
             message: nil,
@@ -42,19 +43,27 @@ final class MenuComponent: BridgeComponent {
             }
             alertController.addAction(action)
         }
-
+        
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        alertController.addAction(cancelAction)
+        alertController.addAction(cancelAction) 
 
-        // Set popoverController for iPads
-        if let popoverController = alertController.popoverPresentationController {
-            if let barButtonItem = viewController?.navigationItem.rightBarButtonItem {
-                popoverController.barButtonItem = barButtonItem
-            } else {
-                popoverController.sourceView = viewController?.view
-                popoverController.sourceRect = viewController?.view.bounds ?? .zero
-                popoverController.permittedArrowDirections = []
-            }
+        // Set popoverController for devices that support them (iPad, iOS 26+)
+        if let popoverController = alertController.popoverPresentationController,
+           let vc = viewController as? Visitable,
+           let sourceView = viewController?.view,
+           let webView = vc.visitableView.webView
+        {
+            popoverController.sourceView = sourceView
+
+            // The source coordinates come from the bridge component relative to the web page content.
+            // The web view's scroll view has content insets for the navigation bar,
+            // so we need to account for the inset at the top.
+            let contentInsetTop = webView.scrollView.adjustedContentInset.top
+            let y = source.y + Double(contentInsetTop)
+
+            popoverController.sourceRect = CGRect(
+                x: source.x, y: y, width: source.width, height: source.height
+            )
         }
 
         viewController?.present(alertController, animated: true)
@@ -79,9 +88,17 @@ private extension MenuComponent {
 // MARK: Message data
 
 private extension MenuComponent {
+    struct Source: Decodable {
+        let x: Double
+        let y: Double
+        let width: Double
+        let height: Double
+    }
+
     struct MessageData: Decodable {
         let title: String
         let items: [Item]
+        let source: Source
     }
 
     struct Item: Decodable {


### PR DESCRIPTION
Since iOS 26 this code also triggers on iPhone, causing the menu to position itself over other menus (for example when you have a `UIMenu`/ overflow menu on the page as well it attaches to the top right icon). It also does not render the cancel button and looks different.

~~I talked to @joemasilotti and he suggested adding the UIDevice check.~~

**UPDATE**: discussed further down, I changed it to position the action sheet based on the coordinates and size of the element that opened the menu.

This also requires sending additional data via the bridge, there's a PR in the demo app for that here: https://github.com/hotwired/hotwire-native-demo/pull/105

This also already works on iPad on older iOS versions as well, see the screenshots below.

| device | before | after |
| - |  - | - |
| iPhone iOS 26 | <img width="1408" height="2770" alt="RocketSim_Screenshot_iPhone_17_Pro_6 3_2025-10-28_12 56 08" src="https://github.com/user-attachments/assets/3165d246-3eda-415a-8dad-a492e7c057d9" /> | <img width="1408" height="2770" alt="RocketSim_Screenshot_iPhone_17_6 3_2025-12-02_14 49 37" src="https://github.com/user-attachments/assets/93f1f846-5e59-4ed8-9f67-54cb5623f1fe" /> |
| iOS iOS 18 | <img width="1396" height="2704" alt="RocketSim_Screenshot_iPhone_16e_6 1_2025-10-28_12 57 00" src="https://github.com/user-attachments/assets/f902c304-9728-4628-981f-8a37a5e209c7" /> | <img width="1380" height="2704" alt="RocketSim_Screenshot_iPhone_16_6 1_2025-12-02_14 56 27" src="https://github.com/user-attachments/assets/9eeba372-afb1-4a5a-b801-e3418f83fb29" /> |
| iPad iOS 26 | <img width="1956" height="2672" alt="RocketSim_Screenshot_iPad_(A16)_10 9_2025-12-02_15 07 43" src="https://github.com/user-attachments/assets/76e27863-1a36-4d59-8b64-08fe53560c43" /> | <img width="1956" height="2672" alt="RocketSim_Screenshot_iPad_(A16)_10 9_2025-12-02_15 02 59" src="https://github.com/user-attachments/assets/c2b45f10-b1ea-4af2-9b56-0850ba41f4ad" /> |
| iPad iOS 18 | <img width="1956" height="2672" alt="RocketSim_Screenshot_iPad_(A16)_10 9_2025-10-28_13 02 05" src="https://github.com/user-attachments/assets/c68994b5-6999-4780-a19b-2b8442dd2c31" /> | <img width="1956" height="2672" alt="RocketSim_Screenshot_iPad_(A16)_10 9_2025-12-02_14 56 24" src="https://github.com/user-attachments/assets/a7dcfdb4-81a2-447f-977a-02601039c848" /> |