### PR TITLE
Fix TabBarMinimize and prefersLargeTitle behaviour

### DIFF
--- a/Source/Turbo/Visitable/Visitable.swift
+++ b/Source/Turbo/Visitable/Visitable.swift
@@ -49,11 +49,22 @@ extension Visitable {
 
     func activateVisitableWebView(_ webView: WKWebView) {
         visitableView.activateWebView(webView, forVisitable: self)
+        // Explicitly designate the web view's scroll view as the tracked content
+        // scroll view so behaviour like UINavigationBar.prefersLargeTitles and the
+        // iOS 26 tab bar minimize trigger reliably, without depending on UIKit's
+        // subview-ordering heuristic. `.all` covers the top (nav bar) and bottom
+        // (tab bar) edges.
+        if #available(iOS 15.0, *) {
+            visitableViewController.setContentScrollView(webView.scrollView, for: .all)
+        }
         visitableDidActivateWebView(webView)
     }
 
     func deactivateVisitableWebView() {
         visitableWillDeactivateWebView()
+        if #available(iOS 15.0, *) {
+            visitableViewController.setContentScrollView(nil, for: .all)
+        }
         visitableView.deactivateWebView()
         visitableDidDeactivateWebView()
     }

--- a/Source/Turbo/Visitable/VisitableView.swift
+++ b/Source/Turbo/Visitable/VisitableView.swift
@@ -24,7 +24,10 @@ open class VisitableView: UIView {
     open func activateWebView(_ webView: WKWebView, forVisitable visitable: Visitable) {
         self.webView = webView
         self.visitable = visitable
-        addSubview(webView)
+        // For behaviour like UINavigationBar.prefersLargeTitles or
+        // TabBarMinimize to work the scrollable view shoud be the
+        // first child in the hierarchy from the moment it is added.
+        insertSubview(webView, at: 0)
         addFillConstraints(for: webView)
         installRefreshControl()
         showOrHideWebView()

--- a/Source/Turbo/Visitable/VisitableView.swift
+++ b/Source/Turbo/Visitable/VisitableView.swift
@@ -24,9 +24,9 @@ open class VisitableView: UIView {
     open func activateWebView(_ webView: WKWebView, forVisitable visitable: Visitable) {
         self.webView = webView
         self.visitable = visitable
-        // For behaviour like UINavigationBar.prefersLargeTitles or
-        // TabBarMinimize to work the scrollable view shoud be the
-        // first child in the hierarchy from the moment it is added.
+        // iOS 14 fallback: with no explicit contentScrollView, UIKit's heuristic requires
+        // the scrollable view to be the first subview for large-title / tab-bar-minimize
+        // to work. On iOS 15+ this is made robust by setContentScrollView in Visitable.
         insertSubview(webView, at: 0)
         addFillConstraints(for: webView)
         installRefreshControl()

--- a/Tests/Turbo/VisitableViewControllerTests.swift
+++ b/Tests/Turbo/VisitableViewControllerTests.swift
@@ -47,6 +47,30 @@ class VisitableViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.initialVisitableURL, originalURL)
         XCTAssertEqual(viewController.currentVisitableURL, overriddenURL)
     }
+
+    func test_webview_is_first_child_during_loading() {
+        XCTAssertEqual(viewController.visitableView.subviews.first, viewController.visitableView.activityIndicatorView)
+
+        viewController.visitableView.activateWebView(webView, forVisitable: viewController)
+
+        XCTAssertEqual(viewController.visitableView.subviews.first, webView)
+        XCTAssertEqual(viewController.visitableView.subviews.last, viewController.visitableView.activityIndicatorView)
+    }
+
+    func test_webview_is_first_child_on_restore() {
+        XCTAssertEqual(viewController.visitableView.subviews.first, viewController.visitableView.activityIndicatorView)
+
+        viewController.showVisitableScreenshot()
+        viewController.visitableView.activateWebView(webView, forVisitable: viewController)
+
+        XCTAssertEqual(viewController.visitableView.subviews.count, 3)
+        XCTAssertEqual(viewController.visitableView.subviews.first, viewController.visitableView.webView)
+
+        viewController.hideVisitableScreenshot()
+
+        XCTAssertEqual(viewController.visitableView.subviews.count, 2)
+        XCTAssertEqual(viewController.visitableView.subviews.first, viewController.visitableView.webView)
+    }
 }
 
 final class WebViewSpy: WKWebView {

--- a/Tests/Turbo/VisitableViewControllerTests.swift
+++ b/Tests/Turbo/VisitableViewControllerTests.swift
@@ -71,6 +71,26 @@ class VisitableViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.visitableView.subviews.count, 2)
         XCTAssertEqual(viewController.visitableView.subviews.first, viewController.visitableView.webView)
     }
+
+    @available(iOS 15.0, *)
+    func test_activating_webview_designates_its_scroll_view_as_content_scroll_view() {
+        XCTAssertNil(viewController.contentScrollView(for: .top))
+
+        viewController.activateVisitableWebView(webView)
+
+        XCTAssertEqual(viewController.contentScrollView(for: .top), webView.scrollView)
+        XCTAssertEqual(viewController.contentScrollView(for: .bottom), webView.scrollView)
+    }
+
+    @available(iOS 15.0, *)
+    func test_deactivating_webview_clears_the_content_scroll_view() {
+        viewController.activateVisitableWebView(webView)
+        XCTAssertEqual(viewController.contentScrollView(for: .top), webView.scrollView)
+
+        viewController.deactivateVisitableWebView()
+
+        XCTAssertNil(viewController.contentScrollView(for: .top))
+    }
 }
 
 final class WebViewSpy: WKWebView {


### PR DESCRIPTION
I recently delved into an issue with the new [TabBarMinimize](https://developer.apple.com/documentation/swiftui/tabbarminimizebehavior/) functionality in iOS 26.  For certain visits the minimize behavior would not trigger on scroll resulting in an unpredictable user experience.

Based on my findings the scrolling of the webView is not always detected by the TabBarController, therefore not triggering the minimized state of the tab bar.  This also seems to extend to other functionality that triggers on scroll like the prefersLargeTitle configuration.

Based on my initial findings the issue appears to be that the webView in HotwireNative is not always the first child in the view hierarchy when the view appears.  In HotwireNative we have several other views, like the `screenshotContainerView` and `activityIndicatorView` that are added and removed depending on the loading state of the page.

The proposed fix is to always place the webView as the first view in the hierarchy using insertSubview.

A better solution might be to rework the way we add views to the VisitableView such that the webview is always the first child.  While I attempted such a solution I found that using insertSubview is more explicit and less likely to break by future changes to this file.

I have included more specific details in the commit description.

Would love to see this fixed in a future release.  Also happy to discuss and look into any alternatives.

## Example

At the moment I cannot share any examples from the app I am working on.  However, I was able to use the [demo app](https://native.hotwired.dev/ios/getting-started) to re-create the issue using the following SceneDelegate:

```swift
// SceneDelegate.swift
import HotwireNative
import UIKit

let rootURL = URL(string: "https://hotwire-native-demo.dev")!

class CustomNavigationController: HotwireNavigationController {
    override func viewDidLoad() {
        super.viewDidLoad()
        navigationBar.prefersLargeTitles = true
    }
}

class SceneDelegate: UIResponder, UIWindowSceneDelegate {
    var window: UIWindow?

    private let navigator = Navigator(configuration: .init(
        name: "main",
        startLocation: rootURL
    ))

    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        Hotwire.config.defaultNavigationController = { CustomNavigationController() }
        window?.rootViewController = navigator.rootViewController
        navigator.start()
    }
}
```

#### Before

https://github.com/user-attachments/assets/284db92f-d678-4d03-b6e0-02483d04629c 

#### After

https://github.com/user-attachments/assets/6c6708ac-e41f-4a98-996c-cb9035e12764

[^1]: https://swiftsenpai.com/development/large-title-uinavigationbar-glitches/
[^2]: https://github.com/software-mansion/react-native-screens/issues/1034