### PR TITLE
Retrieve navigators by ID, not `HotwireTab`

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Source/Turbo/ViewControllers/HotwireTabBarController.swift
+++ b/Source/Turbo/ViewControllers/HotwireTabBarController.swift
@@ -40,13 +40,13 @@ open class HotwireTabBarController: UITabBarController, NavigationHandler {
         activeNavigator.start()
     }
 
-    /// Returns the navigator associated with the given tab.
+    /// Returns the navigator associated with the given tab's identifier.
     ///
-    /// - Parameter tab: The `HotwireTab` whose associated navigator to retrieve.
+    /// - Parameter identifier: The id of the `HotwireTab` whose associated navigator to retrieve.
     /// - Returns: The existing `Navigator` instance for `tab`, or `nil` if the tab is not part of
     ///   the current configuration or the navigators have not been initialized yet (e.g., before `load(_:)`).
-    public func navigator(for tab: HotwireTab) -> Navigator? {
-        return navigatorsByIdentifier[tab.id]
+    public func navigator(for id: String) -> Navigator? {
+        return navigatorsByIdentifier[id]
     }
 
     // MARK: NavigationHandler


### PR DESCRIPTION
#197 introduced `navigator(for:)` to retrieve a `Navigator` instance for a given `HotwireTab`. In the implementation, this queried the private `navigatorsByIdentifier` based on the tab's ID.

To actually use this function, developers need to create a new `HotwireTab` instance. Which, given its three required parameters, is quite verbose to create.

This PR reworks the parameter to only require a `String` identifier to find the `Navigator`. This makes it easier for developer's to use the function and doesn't change any underlying functionality.