### PR TITLE
Structured errors unit tests

### DIFF
--- a/Tests/Turbo/HotwireNativeErrorTests.swift
+++ b/Tests/Turbo/HotwireNativeErrorTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import HotwireNative
+
+class HotwireNativeErrorTests: XCTestCase {
+
+    // MARK: - Turbo.js SystemStatusCode Mapping
+    //
+    // These correspond to the three SystemStatusCode values defined in turbo/src/core/drive/visit.js.
+    // They are the ONLY non-positive codes Turbo.js sends today.
+
+    func test_turboJSStatusCode_networkFailure_createsWebError() {
+        // SystemStatusCode.networkFailure = 0 (fetch errored completely)
+        let error = HotwireNativeError(turboJSStatusCode: 0)
+        if case .web(let webError) = error {
+            XCTAssertEqual(webError.errorCode, 0)
+            XCTAssertNil(webError.urlError)
+        } else {
+            XCTFail("Expected .web error, got \(error)")
+        }
+    }
+
+    func test_turboJSStatusCode_timeoutFailure_createsTimeoutWebError() {
+        // SystemStatusCode.timeoutFailure = -1
+        let error = HotwireNativeError(turboJSStatusCode: -1)
+        if case .web(let webError) = error {
+            XCTAssertTrue(webError.isTimeout)
+            XCTAssertEqual(webError.errorCode, -1)
+        } else {
+            XCTFail("Expected .web error, got \(error)")
+        }
+    }
+
+    func test_turboJSStatusCode_contentTypeMismatch_createsLoadError() {
+        // SystemStatusCode.contentTypeMismatch = -2 (non-HTML response)
+        let error = HotwireNativeError(turboJSStatusCode: -2)
+        XCTAssertEqual(error, .load(.contentTypeMismatch))
+    }
+
+    // MARK: - HTTP Status Codes via visitRequestFailed
+    //
+    // When the server returns a non-2xx status code, Turbo.js calls
+    // adapter.visitRequestFailedWithStatusCode(visit, statusCode).
+    // The iOS native adapter routes positive codes through visitRequestFailed →
+    // JavaScriptVisit → HotwireNativeError(turboJSStatusCode:).
+    // Consumers then pattern-match in NavigatorDelegate.visitableDidFailRequest.
+
+    func test_turboJSStatusCode_httpErrors_mapToExpectedCases() {
+        let cases: [(Int, HotwireNativeError)] = [
+            (401, .http(.client(.unauthorized))),
+            (403, .http(.client(.forbidden))),
+            (404, .http(.client(.notFound))),
+            (422, .http(.client(.unprocessableEntity))),
+            (429, .http(.client(.tooManyRequests))),
+            (500, .http(.server(.internalServerError))),
+            (502, .http(.server(.badGateway))),
+            (503, .http(.server(.serviceUnavailable))),
+        ]
+
+        for (statusCode, expected) in cases {
+            let error = HotwireNativeError(turboJSStatusCode: statusCode)
+            XCTAssertEqual(error, expected, "Status code \(statusCode) should map to \(expected)")
+        }
+    }
+
+    // MARK: - Unknown 4xx/5xx Codes
+    //
+    // Valid HTTP error codes the enum doesn't name explicitly.
+    // These are real Turbo.js scenarios — the server can return any 4xx/5xx.
+
+    func test_turboJSStatusCode_unknown4xx5xx_mapToOtherCases() {
+        let cases: [(Int, HotwireNativeError)] = [
+            (410, .http(.client(.other(statusCode: 410)))),   // 410 Gone
+            (418, .http(.client(.other(statusCode: 418)))),   // 418 I'm a Teapot
+            (451, .http(.client(.other(statusCode: 451)))),   // 451 Unavailable For Legal Reasons
+            (506, .http(.server(.other(statusCode: 506)))),   // 506 Variant Also Negotiates
+            (520, .http(.server(.other(statusCode: 520)))),   // 520 Cloudflare-specific
+        ]
+
+        for (statusCode, expected) in cases {
+            let error = HotwireNativeError(turboJSStatusCode: statusCode)
+            XCTAssertEqual(error, expected, "Unknown status code \(statusCode) should fall through to .other")
+        }
+    }
+
+    // MARK: - Unexpected Codes
+    //
+    // Values that shouldn't realistically arrive through Turbo.js today.
+    // Negative codes not in SystemStatusCode, or 1xx/2xx/3xx (browser handles redirects,
+    // Turbo.js considers 200-299 successful). These test defensive fallback behavior.
+
+    func test_turboJSStatusCode_unexpectedNegative_createsWebError() {
+        // Turbo.js only defines -2, -1, 0 — but future versions could add more
+        let error = HotwireNativeError(turboJSStatusCode: -3)
+        if case .web(let webError) = error {
+            XCTAssertEqual(webError.errorCode, -3)
+        } else {
+            XCTFail("Expected .web error for unexpected negative code, got \(error)")
+        }
+    }
+
+    func test_turboJSStatusCode_unexpectedPositive_createsUnknownHttpError() {
+        // 1xx and 3xx can't reach Turbo.js through normal flow
+        let cases: [(Int, HotwireNativeError)] = [
+            (100, .http(.unknownError(statusCode: 100))),
+            (301, .http(.unknownError(statusCode: 301))),
+        ]
+
+        for (statusCode, expected) in cases {
+            let error = HotwireNativeError(turboJSStatusCode: statusCode)
+            XCTAssertEqual(error, expected, "Unexpected code \(statusCode) should map to .unknownError")
+        }
+    }
+
+    // MARK: - Convenience Properties
+
+    func test_statusCode_returnsCode_forHttpError() {
+        let error = HotwireNativeError.http(.client(.unauthorized))
+        XCTAssertEqual(error.statusCode, 401)
+    }
+
+    func test_statusCode_returnsNil_forNonHttpErrors() {
+        let cases: [HotwireNativeError] = [
+            .web(WebError(errorCode: 0, description: nil)),
+            .load(.notPresent),
+        ]
+
+        for error in cases {
+            XCTAssertNil(error.statusCode, "\(error) should not have a statusCode")
+        }
+    }
+
+    func test_urlError_returnsURLError_forWebErrorWithURLError() {
+        let urlError = URLError(.notConnectedToInternet)
+        let error = HotwireNativeError.web(WebError(urlError: urlError))
+        XCTAssertEqual(error.urlError, urlError)
+    }
+
+    func test_urlError_returnsNil_forNonWebErrors() {
+        let cases: [HotwireNativeError] = [
+            .http(.client(.notFound)),
+            .load(.notPresent),
+        ]
+
+        for error in cases {
+            XCTAssertNil(error.urlError, "\(error) should not have a urlError")
+        }
+    }
+
+    // MARK: - Error Descriptions
+
+    func test_errorDescription_delegatesToInnerErrorType() {
+        let cases: [(HotwireNativeError, String)] = [
+            (.http(.client(.notFound)), "Not Found"),
+            (.web(WebError(urlError: URLError(.notConnectedToInternet))), "Could not connect to the server."),
+            (.load(.contentTypeMismatch), "The server returned an invalid content type."),
+        ]
+
+        for (error, expectedDescription) in cases {
+            XCTAssertEqual(error.errorDescription, expectedDescription)
+        }
+    }
+}

--- a/Tests/Turbo/HotwireNativeErrorTests.swift
+++ b/Tests/Turbo/HotwireNativeErrorTests.swift
@@ -1,133 +1,133 @@
 import XCTest
 @testable import HotwireNative
 
-class HotwireNativeErrorTests: XCTestCase {
+final class HotwireNativeErrorTests: XCTestCase {
 
     // MARK: - Turbo.js SystemStatusCode Mapping
-    //
-    // These correspond to the three SystemStatusCode values defined in turbo/src/core/drive/visit.js.
-    // They are the ONLY non-positive codes Turbo.js sends today.
 
-    func test_turboJSStatusCode_networkFailure_createsWebError() {
-        // SystemStatusCode.networkFailure = 0 (fetch errored completely)
+    func test_turboJSStatusCode_0_createsWebError_networkFailure() {
         let error = HotwireNativeError(turboJSStatusCode: 0)
-        if case .web(let webError) = error {
-            XCTAssertEqual(webError.errorCode, 0)
-            XCTAssertNil(webError.urlError)
-        } else {
-            XCTFail("Expected .web error, got \(error)")
-        }
+        XCTAssertEqual(error, .web(WebError(errorCode: 0, description: "Network failure")))
     }
 
-    func test_turboJSStatusCode_timeoutFailure_createsTimeoutWebError() {
-        // SystemStatusCode.timeoutFailure = -1
+    func test_turboJSStatusCode_negative1_createsWebError_timeout() {
+        let error = HotwireNativeError(turboJSStatusCode: -1)
+        XCTAssertEqual(error, .web(WebError(errorCode: -1, description: "Timeout")))
+    }
+
+    func test_turboJSStatusCode_negative1_webError_isTimeout() {
         let error = HotwireNativeError(turboJSStatusCode: -1)
         if case .web(let webError) = error {
             XCTAssertTrue(webError.isTimeout)
-            XCTAssertEqual(webError.errorCode, -1)
         } else {
-            XCTFail("Expected .web error, got \(error)")
+            XCTFail("Expected .web, got \(error)")
         }
     }
 
-    func test_turboJSStatusCode_contentTypeMismatch_createsLoadError() {
-        // SystemStatusCode.contentTypeMismatch = -2 (non-HTML response)
-        let error = HotwireNativeError(turboJSStatusCode: -2)
-        XCTAssertEqual(error, .load(.contentTypeMismatch))
+    func test_turboJSStatusCode_negative2_createsContentTypeMismatchLoadError() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: -2), .load(.contentTypeMismatch))
     }
 
-    // MARK: - HTTP Status Codes via visitRequestFailed
-    //
-    // When the server returns a non-2xx status code, Turbo.js calls
-    // adapter.visitRequestFailedWithStatusCode(visit, statusCode).
-    // The iOS native adapter routes positive codes through visitRequestFailed →
-    // JavaScriptVisit → HotwireNativeError(turboJSStatusCode:).
-    // Consumers then pattern-match in NavigatorDelegate.visitableDidFailRequest.
+    // MARK: - HTTP Status Code Mapping
 
-    func test_turboJSStatusCode_httpErrors_mapToExpectedCases() {
-        let cases: [(Int, HotwireNativeError)] = [
-            (401, .http(.client(.unauthorized))),
-            (403, .http(.client(.forbidden))),
-            (404, .http(.client(.notFound))),
-            (422, .http(.client(.unprocessableEntity))),
-            (429, .http(.client(.tooManyRequests))),
-            (500, .http(.server(.internalServerError))),
-            (502, .http(.server(.badGateway))),
-            (503, .http(.server(.serviceUnavailable))),
-        ]
-
-        for (statusCode, expected) in cases {
-            let error = HotwireNativeError(turboJSStatusCode: statusCode)
-            XCTAssertEqual(error, expected, "Status code \(statusCode) should map to \(expected)")
-        }
+    func test_turboJSStatusCode_401_mapsToUnauthorized() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 401), .http(.client(.unauthorized)))
     }
 
-    // MARK: - Unknown 4xx/5xx Codes
-    //
-    // Valid HTTP error codes the enum doesn't name explicitly.
-    // These are real Turbo.js scenarios — the server can return any 4xx/5xx.
-
-    func test_turboJSStatusCode_unknown4xx5xx_mapToOtherCases() {
-        let cases: [(Int, HotwireNativeError)] = [
-            (410, .http(.client(.other(statusCode: 410)))),   // 410 Gone
-            (418, .http(.client(.other(statusCode: 418)))),   // 418 I'm a Teapot
-            (451, .http(.client(.other(statusCode: 451)))),   // 451 Unavailable For Legal Reasons
-            (506, .http(.server(.other(statusCode: 506)))),   // 506 Variant Also Negotiates
-            (520, .http(.server(.other(statusCode: 520)))),   // 520 Cloudflare-specific
-        ]
-
-        for (statusCode, expected) in cases {
-            let error = HotwireNativeError(turboJSStatusCode: statusCode)
-            XCTAssertEqual(error, expected, "Unknown status code \(statusCode) should fall through to .other")
-        }
+    func test_turboJSStatusCode_403_mapsToForbidden() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 403), .http(.client(.forbidden)))
     }
 
-    // MARK: - Unexpected Codes
-    //
-    // Values that shouldn't realistically arrive through Turbo.js today.
-    // Negative codes not in SystemStatusCode, or 1xx/2xx/3xx (browser handles redirects,
-    // Turbo.js considers 200-299 successful). These test defensive fallback behavior.
+    func test_turboJSStatusCode_404_mapsToNotFound() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 404), .http(.client(.notFound)))
+    }
 
-    func test_turboJSStatusCode_unexpectedNegative_createsWebError() {
-        // Turbo.js only defines -2, -1, 0 — but future versions could add more
+    func test_turboJSStatusCode_422_mapsToUnprocessableEntity() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 422), .http(.client(.unprocessableEntity)))
+    }
+
+    func test_turboJSStatusCode_429_mapsToTooManyRequests() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 429), .http(.client(.tooManyRequests)))
+    }
+
+    func test_turboJSStatusCode_500_mapsToInternalServerError() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 500), .http(.server(.internalServerError)))
+    }
+
+    func test_turboJSStatusCode_502_mapsToBadGateway() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 502), .http(.server(.badGateway)))
+    }
+
+    func test_turboJSStatusCode_503_mapsToServiceUnavailable() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 503), .http(.server(.serviceUnavailable)))
+    }
+
+    // MARK: - Unknown 4xx/5xx -> .other
+
+    func test_turboJSStatusCode_410_mapsToClientOther() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 410), .http(.client(.other(statusCode: 410))))
+    }
+
+    func test_turboJSStatusCode_418_mapsToClientOther() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 418), .http(.client(.other(statusCode: 418))))
+    }
+
+    func test_turboJSStatusCode_451_mapsToClientOther() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 451), .http(.client(.other(statusCode: 451))))
+    }
+
+    func test_turboJSStatusCode_506_mapsToServerOther() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 506), .http(.server(.other(statusCode: 506))))
+    }
+
+    func test_turboJSStatusCode_520_mapsToServerOther() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 520), .http(.server(.other(statusCode: 520))))
+    }
+
+    // MARK: - Unexpected Negative Codes -> .web
+
+    func test_turboJSStatusCode_negative3_createsWebError() {
         let error = HotwireNativeError(turboJSStatusCode: -3)
-        if case .web(let webError) = error {
-            XCTAssertEqual(webError.errorCode, -3)
-        } else {
-            XCTFail("Expected .web error for unexpected negative code, got \(error)")
-        }
+        XCTAssertEqual(error, .web(WebError(errorCode: -3, description: "Network error")))
     }
 
-    func test_turboJSStatusCode_unexpectedPositive_createsUnknownHttpError() {
-        // 1xx and 3xx can't reach Turbo.js through normal flow
-        let cases: [(Int, HotwireNativeError)] = [
-            (100, .http(.unknownError(statusCode: 100))),
-            (301, .http(.unknownError(statusCode: 301))),
-        ]
+    // MARK: - Unexpected Positive Non-HTTP Codes -> .unknownError
 
-        for (statusCode, expected) in cases {
-            let error = HotwireNativeError(turboJSStatusCode: statusCode)
-            XCTAssertEqual(error, expected, "Unexpected code \(statusCode) should map to .unknownError")
-        }
+    func test_turboJSStatusCode_1_mapsToUnknownHttpError() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 1), .http(.unknownError(statusCode: 1)))
     }
 
-    // MARK: - Convenience Properties
-
-    func test_statusCode_returnsCode_forHttpError() {
-        let error = HotwireNativeError.http(.client(.unauthorized))
-        XCTAssertEqual(error.statusCode, 401)
+    func test_turboJSStatusCode_100_mapsToUnknownHttpError() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 100), .http(.unknownError(statusCode: 100)))
     }
 
-    func test_statusCode_returnsNil_forNonHttpErrors() {
-        let cases: [HotwireNativeError] = [
-            .web(WebError(errorCode: 0, description: nil)),
-            .load(.notPresent),
-        ]
-
-        for error in cases {
-            XCTAssertNil(error.statusCode, "\(error) should not have a statusCode")
-        }
+    func test_turboJSStatusCode_301_mapsToUnknownHttpError() {
+        XCTAssertEqual(HotwireNativeError(turboJSStatusCode: 301), .http(.unknownError(statusCode: 301)))
     }
+
+    // MARK: - statusCode
+
+    func test_statusCode_returnsCode_forClientHttpError() {
+        XCTAssertEqual(HotwireNativeError.http(.client(.unauthorized)).statusCode, 401)
+    }
+
+    func test_statusCode_returnsCode_forServerHttpError() {
+        XCTAssertEqual(HotwireNativeError.http(.server(.badGateway)).statusCode, 502)
+    }
+
+    func test_statusCode_returnsCode_forUnknownHttpError() {
+        XCTAssertEqual(HotwireNativeError.http(.unknownError(statusCode: 100)).statusCode, 100)
+    }
+
+    func test_statusCode_returnsNil_forWebError() {
+        XCTAssertNil(HotwireNativeError.web(WebError(errorCode: 0, description: nil)).statusCode)
+    }
+
+    func test_statusCode_returnsNil_forLoadError() {
+        XCTAssertNil(HotwireNativeError.load(.notPresent).statusCode)
+    }
+
+    // MARK: - urlError
 
     func test_urlError_returnsURLError_forWebErrorWithURLError() {
         let urlError = URLError(.notConnectedToInternet)
@@ -135,28 +135,34 @@ class HotwireNativeErrorTests: XCTestCase {
         XCTAssertEqual(error.urlError, urlError)
     }
 
-    func test_urlError_returnsNil_forNonWebErrors() {
-        let cases: [HotwireNativeError] = [
-            .http(.client(.notFound)),
-            .load(.notPresent),
-        ]
-
-        for error in cases {
-            XCTAssertNil(error.urlError, "\(error) should not have a urlError")
-        }
+    func test_urlError_returnsNil_forWebErrorWithoutURLError() {
+        let error = HotwireNativeError.web(WebError(errorCode: 0, description: nil))
+        XCTAssertNil(error.urlError)
     }
 
-    // MARK: - Error Descriptions
+    func test_urlError_returnsNil_forHttpError() {
+        XCTAssertNil(HotwireNativeError.http(.client(.notFound)).urlError)
+    }
 
-    func test_errorDescription_delegatesToInnerErrorType() {
-        let cases: [(HotwireNativeError, String)] = [
-            (.http(.client(.notFound)), "Not Found"),
-            (.web(WebError(urlError: URLError(.notConnectedToInternet))), "Could not connect to the server."),
-            (.load(.contentTypeMismatch), "The server returned an invalid content type."),
-        ]
+    func test_urlError_returnsNil_forLoadError() {
+        XCTAssertNil(HotwireNativeError.load(.notPresent).urlError)
+    }
 
-        for (error, expectedDescription) in cases {
-            XCTAssertEqual(error.errorDescription, expectedDescription)
-        }
+    // MARK: - errorDescription
+
+    func test_errorDescription_forHttpError() {
+        XCTAssertEqual(HotwireNativeError.http(.client(.notFound)).errorDescription, "Not Found")
+    }
+
+    func test_errorDescription_forWebError() {
+        let error = HotwireNativeError.web(WebError(urlError: URLError(.notConnectedToInternet)))
+        XCTAssertEqual(error.errorDescription, "Could not connect to the server.")
+    }
+
+    func test_errorDescription_forLoadError() {
+        XCTAssertEqual(
+            HotwireNativeError.load(.contentTypeMismatch).errorDescription,
+            "The server returned an invalid content type."
+        )
     }
 }

--- a/Tests/Turbo/HttpErrorTests.swift
+++ b/Tests/Turbo/HttpErrorTests.swift
@@ -1,123 +1,213 @@
 import XCTest
 @testable import HotwireNative
 
-class HttpErrorTests: XCTestCase {
+final class HttpErrorTests: XCTestCase {
 
-    // MARK: - Status Code Range Boundaries
+    // MARK: - from(statusCode:) Range Boundaries
 
-    func test_from_statusCode_routesToCorrectCategory() {
-        let cases: [(Int, String)] = [
-            (399, "unknownError"),   // below client range
-            (400, "client"),         // start of client range
-            (499, "client"),         // end of client range
-            (500, "server"),         // start of server range
-            (599, "server"),         // end of server range
-            (600, "unknownError"),   // above server range
-        ]
-
-        for (statusCode, expectedCategory) in cases {
-            let error = HttpError.from(statusCode: statusCode)
-            switch (error, expectedCategory) {
-            case (.client, "client"),
-                 (.server, "server"),
-                 (.unknownError, "unknownError"):
-                break // correct
-            default:
-                XCTFail("Status code \(statusCode) should be \(expectedCategory), got \(error)")
-            }
-        }
+    func test_from_statusCode1_isUnknownError() {
+        XCTAssertEqual(HttpError.from(statusCode: 1), .unknownError(statusCode: 1))
     }
 
-    // MARK: - ClientError Status Code Round-Trip
-
-    func test_clientError_statusCode_roundTrips() {
-        let cases: [(HttpError.ClientError, Int)] = [
-            (.badRequest, 400),
-            (.unauthorized, 401),
-            (.paymentRequired, 402),
-            (.forbidden, 403),
-            (.notFound, 404),
-            (.methodNotAllowed, 405),
-            (.notAcceptable, 406),
-            (.proxyAuthenticationRequired, 407),
-            (.requestTimeout, 408),
-            (.conflict, 409),
-            (.misdirectedRequest, 421),
-            (.unprocessableEntity, 422),
-            (.preconditionRequired, 428),
-            (.tooManyRequests, 429),
-        ]
-
-        for (expectedCase, statusCode) in cases {
-            let created = HttpError.ClientError.from(statusCode: statusCode)
-            XCTAssertEqual(created, expectedCase, "Status code \(statusCode) should map to \(expectedCase)")
-            XCTAssertEqual(created.statusCode, statusCode, "Round-trip failed for \(expectedCase)")
-        }
+    func test_from_statusCode399_isUnknownError() {
+        XCTAssertEqual(HttpError.from(statusCode: 399), .unknownError(statusCode: 399))
     }
 
-    // MARK: - ServerError Status Code Round-Trip
-
-    func test_serverError_statusCode_roundTrips() {
-        let cases: [(HttpError.ServerError, Int)] = [
-            (.internalServerError, 500),
-            (.notImplemented, 501),
-            (.badGateway, 502),
-            (.serviceUnavailable, 503),
-            (.gatewayTimeout, 504),
-            (.httpVersionNotSupported, 505),
-        ]
-
-        for (expectedCase, statusCode) in cases {
-            let created = HttpError.ServerError.from(statusCode: statusCode)
-            XCTAssertEqual(created, expectedCase, "Status code \(statusCode) should map to \(expectedCase)")
-            XCTAssertEqual(created.statusCode, statusCode, "Round-trip failed for \(expectedCase)")
-        }
+    func test_from_statusCode400_isClientError() {
+        XCTAssertEqual(HttpError.from(statusCode: 400), .client(.badRequest))
     }
 
-    // MARK: - Unmapped Status Codes
-
-    func test_unmappedStatusCodes_fallToOther() {
-        let cases: [(Int, HttpError)] = [
-            (418, .client(.other(statusCode: 418))),   // I'm a Teapot
-            (451, .client(.other(statusCode: 451))),   // Unavailable For Legal Reasons
-            (599, .server(.other(statusCode: 599))),
-        ]
-
-        for (statusCode, expected) in cases {
-            let error = HttpError.from(statusCode: statusCode)
-            XCTAssertEqual(error, expected, "Unmapped code \(statusCode) should fall to .other")
-            XCTAssertEqual(error.statusCode, statusCode, "Status code should round-trip for .other")
-        }
+    func test_from_statusCode499_isClientError() {
+        XCTAssertEqual(HttpError.from(statusCode: 499), .client(.other(statusCode: 499)))
     }
 
-    // MARK: - Error Descriptions
-
-    func test_clientError_descriptions() {
-        let cases: [(HttpError.ClientError, String)] = [
-            (.unauthorized, "Unauthorized"),
-            (.notFound, "Not Found"),
-            (.tooManyRequests, "Too Many Requests"),
-            (.other(statusCode: 418), "Client Error (418)"),
-        ]
-
-        for (error, expected) in cases {
-            XCTAssertEqual(error.errorDescription, expected)
-        }
+    func test_from_statusCode500_isServerError() {
+        XCTAssertEqual(HttpError.from(statusCode: 500), .server(.internalServerError))
     }
 
-    func test_serverError_descriptions() {
-        let cases: [(HttpError.ServerError, String)] = [
-            (.internalServerError, "Internal Server Error"),
-            (.serviceUnavailable, "Service Unavailable"),
-            (.other(statusCode: 599), "Server Error (599)"),
-        ]
-
-        for (error, expected) in cases {
-            XCTAssertEqual(error.errorDescription, expected)
-        }
+    func test_from_statusCode599_isServerError() {
+        XCTAssertEqual(HttpError.from(statusCode: 599), .server(.other(statusCode: 599)))
     }
+
+    func test_from_statusCode600_isUnknownError() {
+        XCTAssertEqual(HttpError.from(statusCode: 600), .unknownError(statusCode: 600))
+    }
+
+    // MARK: - ClientError Round-Trips
+
+    func test_clientError_badRequest_roundTrips() {
+        assertClientErrorRoundTrip(.badRequest, statusCode: 400)
+    }
+
+    func test_clientError_unauthorized_roundTrips() {
+        assertClientErrorRoundTrip(.unauthorized, statusCode: 401)
+    }
+
+    func test_clientError_paymentRequired_roundTrips() {
+        assertClientErrorRoundTrip(.paymentRequired, statusCode: 402)
+    }
+
+    func test_clientError_forbidden_roundTrips() {
+        assertClientErrorRoundTrip(.forbidden, statusCode: 403)
+    }
+
+    func test_clientError_notFound_roundTrips() {
+        assertClientErrorRoundTrip(.notFound, statusCode: 404)
+    }
+
+    func test_clientError_methodNotAllowed_roundTrips() {
+        assertClientErrorRoundTrip(.methodNotAllowed, statusCode: 405)
+    }
+
+    func test_clientError_notAcceptable_roundTrips() {
+        assertClientErrorRoundTrip(.notAcceptable, statusCode: 406)
+    }
+
+    func test_clientError_proxyAuthenticationRequired_roundTrips() {
+        assertClientErrorRoundTrip(.proxyAuthenticationRequired, statusCode: 407)
+    }
+
+    func test_clientError_requestTimeout_roundTrips() {
+        assertClientErrorRoundTrip(.requestTimeout, statusCode: 408)
+    }
+
+    func test_clientError_conflict_roundTrips() {
+        assertClientErrorRoundTrip(.conflict, statusCode: 409)
+    }
+
+    func test_clientError_misdirectedRequest_roundTrips() {
+        assertClientErrorRoundTrip(.misdirectedRequest, statusCode: 421)
+    }
+
+    func test_clientError_unprocessableEntity_roundTrips() {
+        assertClientErrorRoundTrip(.unprocessableEntity, statusCode: 422)
+    }
+
+    func test_clientError_preconditionRequired_roundTrips() {
+        assertClientErrorRoundTrip(.preconditionRequired, statusCode: 428)
+    }
+
+    func test_clientError_tooManyRequests_roundTrips() {
+        assertClientErrorRoundTrip(.tooManyRequests, statusCode: 429)
+    }
+
+    func test_clientError_unmapped418_fallsToOther() {
+        assertClientErrorRoundTrip(.other(statusCode: 418), statusCode: 418)
+    }
+
+    func test_clientError_unmapped451_fallsToOther() {
+        assertClientErrorRoundTrip(.other(statusCode: 451), statusCode: 451)
+    }
+
+    // MARK: - ServerError Round-Trips
+
+    func test_serverError_internalServerError_roundTrips() {
+        assertServerErrorRoundTrip(.internalServerError, statusCode: 500)
+    }
+
+    func test_serverError_notImplemented_roundTrips() {
+        assertServerErrorRoundTrip(.notImplemented, statusCode: 501)
+    }
+
+    func test_serverError_badGateway_roundTrips() {
+        assertServerErrorRoundTrip(.badGateway, statusCode: 502)
+    }
+
+    func test_serverError_serviceUnavailable_roundTrips() {
+        assertServerErrorRoundTrip(.serviceUnavailable, statusCode: 503)
+    }
+
+    func test_serverError_gatewayTimeout_roundTrips() {
+        assertServerErrorRoundTrip(.gatewayTimeout, statusCode: 504)
+    }
+
+    func test_serverError_httpVersionNotSupported_roundTrips() {
+        assertServerErrorRoundTrip(.httpVersionNotSupported, statusCode: 505)
+    }
+
+    func test_serverError_unmapped599_fallsToOther() {
+        assertServerErrorRoundTrip(.other(statusCode: 599), statusCode: 599)
+    }
+
+    // MARK: - unknownError statusCode
+
+    func test_unknownError_statusCode_roundTrips() {
+        XCTAssertEqual(HttpError.unknownError(statusCode: 600).statusCode, 600)
+    }
+
+    func test_unknownError_statusCode_roundTrips_forLowCode() {
+        XCTAssertEqual(HttpError.unknownError(statusCode: 1).statusCode, 1)
+    }
+
+    // MARK: - HttpError statusCode Delegation
+
+    func test_statusCode_delegatesToClientError() {
+        XCTAssertEqual(HttpError.client(.notFound).statusCode, 404)
+    }
+
+    func test_statusCode_delegatesToServerError() {
+        XCTAssertEqual(HttpError.server(.badGateway).statusCode, 502)
+    }
+
+    // MARK: - ClientError Descriptions
+
+    func test_clientError_unauthorized_description() {
+        XCTAssertEqual(HttpError.ClientError.unauthorized.errorDescription, "Unauthorized")
+    }
+
+    func test_clientError_notFound_description() {
+        XCTAssertEqual(HttpError.ClientError.notFound.errorDescription, "Not Found")
+    }
+
+    func test_clientError_tooManyRequests_description() {
+        XCTAssertEqual(HttpError.ClientError.tooManyRequests.errorDescription, "Too Many Requests")
+    }
+
+    func test_clientError_other_description_includesStatusCode() {
+        XCTAssertEqual(HttpError.ClientError.other(statusCode: 418).errorDescription, "Client Error (418)")
+    }
+
+    // MARK: - ServerError Descriptions
+
+    func test_serverError_internalServerError_description() {
+        XCTAssertEqual(HttpError.ServerError.internalServerError.errorDescription, "Internal Server Error")
+    }
+
+    func test_serverError_serviceUnavailable_description() {
+        XCTAssertEqual(HttpError.ServerError.serviceUnavailable.errorDescription, "Service Unavailable")
+    }
+
+    func test_serverError_other_description_includesStatusCode() {
+        XCTAssertEqual(HttpError.ServerError.other(statusCode: 599).errorDescription, "Server Error (599)")
+    }
+
+    // MARK: - unknownError Description
 
     func test_unknownError_description_includesStatusCode() {
         XCTAssertEqual(HttpError.unknownError(statusCode: 600).errorDescription, "HTTP Error (600)")
+    }
+
+    // MARK: - Helpers
+
+    private func assertClientErrorRoundTrip(
+        _ expected: HttpError.ClientError,
+        statusCode: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let created = HttpError.ClientError.from(statusCode: statusCode)
+        XCTAssertEqual(created, expected, file: file, line: line)
+        XCTAssertEqual(created.statusCode, statusCode, "statusCode round-trip failed", file: file, line: line)
+    }
+
+    private func assertServerErrorRoundTrip(
+        _ expected: HttpError.ServerError,
+        statusCode: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let created = HttpError.ServerError.from(statusCode: statusCode)
+        XCTAssertEqual(created, expected, file: file, line: line)
+        XCTAssertEqual(created.statusCode, statusCode, "statusCode round-trip failed", file: file, line: line)
     }
 }

--- a/Tests/Turbo/HttpErrorTests.swift
+++ b/Tests/Turbo/HttpErrorTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import HotwireNative
+
+class HttpErrorTests: XCTestCase {
+
+    // MARK: - Status Code Range Boundaries
+
+    func test_from_statusCode_routesToCorrectCategory() {
+        let cases: [(Int, String)] = [
+            (399, "unknownError"),   // below client range
+            (400, "client"),         // start of client range
+            (499, "client"),         // end of client range
+            (500, "server"),         // start of server range
+            (599, "server"),         // end of server range
+            (600, "unknownError"),   // above server range
+        ]
+
+        for (statusCode, expectedCategory) in cases {
+            let error = HttpError.from(statusCode: statusCode)
+            switch (error, expectedCategory) {
+            case (.client, "client"),
+                 (.server, "server"),
+                 (.unknownError, "unknownError"):
+                break // correct
+            default:
+                XCTFail("Status code \(statusCode) should be \(expectedCategory), got \(error)")
+            }
+        }
+    }
+
+    // MARK: - ClientError Status Code Round-Trip
+
+    func test_clientError_statusCode_roundTrips() {
+        let cases: [(HttpError.ClientError, Int)] = [
+            (.badRequest, 400),
+            (.unauthorized, 401),
+            (.paymentRequired, 402),
+            (.forbidden, 403),
+            (.notFound, 404),
+            (.methodNotAllowed, 405),
+            (.notAcceptable, 406),
+            (.proxyAuthenticationRequired, 407),
+            (.requestTimeout, 408),
+            (.conflict, 409),
+            (.misdirectedRequest, 421),
+            (.unprocessableEntity, 422),
+            (.preconditionRequired, 428),
+            (.tooManyRequests, 429),
+        ]
+
+        for (expectedCase, statusCode) in cases {
+            let created = HttpError.ClientError.from(statusCode: statusCode)
+            XCTAssertEqual(created, expectedCase, "Status code \(statusCode) should map to \(expectedCase)")
+            XCTAssertEqual(created.statusCode, statusCode, "Round-trip failed for \(expectedCase)")
+        }
+    }
+
+    // MARK: - ServerError Status Code Round-Trip
+
+    func test_serverError_statusCode_roundTrips() {
+        let cases: [(HttpError.ServerError, Int)] = [
+            (.internalServerError, 500),
+            (.notImplemented, 501),
+            (.badGateway, 502),
+            (.serviceUnavailable, 503),
+            (.gatewayTimeout, 504),
+            (.httpVersionNotSupported, 505),
+        ]
+
+        for (expectedCase, statusCode) in cases {
+            let created = HttpError.ServerError.from(statusCode: statusCode)
+            XCTAssertEqual(created, expectedCase, "Status code \(statusCode) should map to \(expectedCase)")
+            XCTAssertEqual(created.statusCode, statusCode, "Round-trip failed for \(expectedCase)")
+        }
+    }
+
+    // MARK: - Unmapped Status Codes
+
+    func test_unmappedStatusCodes_fallToOther() {
+        let cases: [(Int, HttpError)] = [
+            (418, .client(.other(statusCode: 418))),   // I'm a Teapot
+            (451, .client(.other(statusCode: 451))),   // Unavailable For Legal Reasons
+            (599, .server(.other(statusCode: 599))),
+        ]
+
+        for (statusCode, expected) in cases {
+            let error = HttpError.from(statusCode: statusCode)
+            XCTAssertEqual(error, expected, "Unmapped code \(statusCode) should fall to .other")
+            XCTAssertEqual(error.statusCode, statusCode, "Status code should round-trip for .other")
+        }
+    }
+
+    // MARK: - Error Descriptions
+
+    func test_clientError_descriptions() {
+        let cases: [(HttpError.ClientError, String)] = [
+            (.unauthorized, "Unauthorized"),
+            (.notFound, "Not Found"),
+            (.tooManyRequests, "Too Many Requests"),
+            (.other(statusCode: 418), "Client Error (418)"),
+        ]
+
+        for (error, expected) in cases {
+            XCTAssertEqual(error.errorDescription, expected)
+        }
+    }
+
+    func test_serverError_descriptions() {
+        let cases: [(HttpError.ServerError, String)] = [
+            (.internalServerError, "Internal Server Error"),
+            (.serviceUnavailable, "Service Unavailable"),
+            (.other(statusCode: 599), "Server Error (599)"),
+        ]
+
+        for (error, expected) in cases {
+            XCTAssertEqual(error.errorDescription, expected)
+        }
+    }
+
+    func test_unknownError_description_includesStatusCode() {
+        XCTAssertEqual(HttpError.unknownError(statusCode: 600).errorDescription, "HTTP Error (600)")
+    }
+}

--- a/Tests/Turbo/HttpErrorTests.swift
+++ b/Tests/Turbo/HttpErrorTests.swift
@@ -1,36 +1,36 @@
 import XCTest
 @testable import HotwireNative
 
-final class HttpErrorTests: XCTestCase {
+final class HTTPErrorTests: XCTestCase {
 
     // MARK: - from(statusCode:) Range Boundaries
 
     func test_from_statusCode1_isUnknownError() {
-        XCTAssertEqual(HttpError.from(statusCode: 1), .unknownError(statusCode: 1))
+        XCTAssertEqual(HTTPError.from(statusCode: 1), .unknownError(statusCode: 1))
     }
 
     func test_from_statusCode399_isUnknownError() {
-        XCTAssertEqual(HttpError.from(statusCode: 399), .unknownError(statusCode: 399))
+        XCTAssertEqual(HTTPError.from(statusCode: 399), .unknownError(statusCode: 399))
     }
 
     func test_from_statusCode400_isClientError() {
-        XCTAssertEqual(HttpError.from(statusCode: 400), .client(.badRequest))
+        XCTAssertEqual(HTTPError.from(statusCode: 400), .client(.badRequest))
     }
 
     func test_from_statusCode499_isClientError() {
-        XCTAssertEqual(HttpError.from(statusCode: 499), .client(.other(statusCode: 499)))
+        XCTAssertEqual(HTTPError.from(statusCode: 499), .client(.other(statusCode: 499)))
     }
 
     func test_from_statusCode500_isServerError() {
-        XCTAssertEqual(HttpError.from(statusCode: 500), .server(.internalServerError))
+        XCTAssertEqual(HTTPError.from(statusCode: 500), .server(.internalServerError))
     }
 
     func test_from_statusCode599_isServerError() {
-        XCTAssertEqual(HttpError.from(statusCode: 599), .server(.other(statusCode: 599)))
+        XCTAssertEqual(HTTPError.from(statusCode: 599), .server(.other(statusCode: 599)))
     }
 
     func test_from_statusCode600_isUnknownError() {
-        XCTAssertEqual(HttpError.from(statusCode: 600), .unknownError(statusCode: 600))
+        XCTAssertEqual(HTTPError.from(statusCode: 600), .unknownError(statusCode: 600))
     }
 
     // MARK: - ClientError Round-Trips
@@ -132,81 +132,81 @@ final class HttpErrorTests: XCTestCase {
     // MARK: - unknownError statusCode
 
     func test_unknownError_statusCode_roundTrips() {
-        XCTAssertEqual(HttpError.unknownError(statusCode: 600).statusCode, 600)
+        XCTAssertEqual(HTTPError.unknownError(statusCode: 600).statusCode, 600)
     }
 
     func test_unknownError_statusCode_roundTrips_forLowCode() {
-        XCTAssertEqual(HttpError.unknownError(statusCode: 1).statusCode, 1)
+        XCTAssertEqual(HTTPError.unknownError(statusCode: 1).statusCode, 1)
     }
 
-    // MARK: - HttpError statusCode Delegation
+    // MARK: - HTTPError statusCode Delegation
 
     func test_statusCode_delegatesToClientError() {
-        XCTAssertEqual(HttpError.client(.notFound).statusCode, 404)
+        XCTAssertEqual(HTTPError.client(.notFound).statusCode, 404)
     }
 
     func test_statusCode_delegatesToServerError() {
-        XCTAssertEqual(HttpError.server(.badGateway).statusCode, 502)
+        XCTAssertEqual(HTTPError.server(.badGateway).statusCode, 502)
     }
 
     // MARK: - ClientError Descriptions
 
     func test_clientError_unauthorized_description() {
-        XCTAssertEqual(HttpError.ClientError.unauthorized.errorDescription, "Unauthorized")
+        XCTAssertEqual(HTTPError.ClientError.unauthorized.errorDescription, "Unauthorized")
     }
 
     func test_clientError_notFound_description() {
-        XCTAssertEqual(HttpError.ClientError.notFound.errorDescription, "Not Found")
+        XCTAssertEqual(HTTPError.ClientError.notFound.errorDescription, "Not Found")
     }
 
     func test_clientError_tooManyRequests_description() {
-        XCTAssertEqual(HttpError.ClientError.tooManyRequests.errorDescription, "Too Many Requests")
+        XCTAssertEqual(HTTPError.ClientError.tooManyRequests.errorDescription, "Too Many Requests")
     }
 
     func test_clientError_other_description_includesStatusCode() {
-        XCTAssertEqual(HttpError.ClientError.other(statusCode: 418).errorDescription, "Client Error (418)")
+        XCTAssertEqual(HTTPError.ClientError.other(statusCode: 418).errorDescription, "Client Error (418)")
     }
 
     // MARK: - ServerError Descriptions
 
     func test_serverError_internalServerError_description() {
-        XCTAssertEqual(HttpError.ServerError.internalServerError.errorDescription, "Internal Server Error")
+        XCTAssertEqual(HTTPError.ServerError.internalServerError.errorDescription, "Internal Server Error")
     }
 
     func test_serverError_serviceUnavailable_description() {
-        XCTAssertEqual(HttpError.ServerError.serviceUnavailable.errorDescription, "Service Unavailable")
+        XCTAssertEqual(HTTPError.ServerError.serviceUnavailable.errorDescription, "Service Unavailable")
     }
 
     func test_serverError_other_description_includesStatusCode() {
-        XCTAssertEqual(HttpError.ServerError.other(statusCode: 599).errorDescription, "Server Error (599)")
+        XCTAssertEqual(HTTPError.ServerError.other(statusCode: 599).errorDescription, "Server Error (599)")
     }
 
     // MARK: - unknownError Description
 
     func test_unknownError_description_includesStatusCode() {
-        XCTAssertEqual(HttpError.unknownError(statusCode: 600).errorDescription, "HTTP Error (600)")
+        XCTAssertEqual(HTTPError.unknownError(statusCode: 600).errorDescription, "HTTP Error (600)")
     }
 
     // MARK: - Helpers
 
     private func assertClientErrorRoundTrip(
-        _ expected: HttpError.ClientError,
+        _ expected: HTTPError.ClientError,
         statusCode: Int,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let created = HttpError.ClientError.from(statusCode: statusCode)
+        let created = HTTPError.ClientError.from(statusCode: statusCode)
         XCTAssertEqual(created, expected, file: file, line: line)
         XCTAssertEqual(created.statusCode, statusCode, "statusCode round-trip failed", file: file, line: line)
     }
 
     private func assertServerErrorRoundTrip(
-        _ expected: HttpError.ServerError,
+        _ expected: HTTPError.ServerError,
         statusCode: Int,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let created = HttpError.ServerError.from(statusCode: statusCode)
+        let created = HTTPError.ServerError.from(statusCode: statusCode)
         XCTAssertEqual(created, expected, file: file, line: line)
         XCTAssertEqual(created.statusCode, statusCode, "statusCode round-trip failed", file: file, line: line)
     }

--- a/Tests/Turbo/LoadErrorTests.swift
+++ b/Tests/Turbo/LoadErrorTests.swift
@@ -1,18 +1,41 @@
 import XCTest
 @testable import HotwireNative
 
-class LoadErrorTests: XCTestCase {
+final class LoadErrorTests: XCTestCase {
 
-    func test_errorDescriptions() {
-        let cases: [(LoadError, String)] = [
-            (.notPresent, "The page could not be loaded due to a configuration error."),
-            (.notReady, "The page could not be loaded due to a configuration error."),
-            (.contentTypeMismatch, "The server returned an invalid content type."),
-            (.invalidResponse, "The server returned an invalid response."),
-        ]
+    // MARK: - errorDescription
 
-        for (error, expected) in cases {
-            XCTAssertEqual(error.errorDescription, expected)
-        }
+    func test_errorDescription_notPresent() {
+        XCTAssertEqual(LoadError.notPresent.errorDescription, "The page could not be loaded due to a configuration error.")
+    }
+
+    func test_errorDescription_notReady() {
+        XCTAssertEqual(LoadError.notReady.errorDescription, "The page could not be loaded due to a configuration error.")
+    }
+
+    func test_errorDescription_contentTypeMismatch() {
+        XCTAssertEqual(LoadError.contentTypeMismatch.errorDescription, "The server returned an invalid content type.")
+    }
+
+    func test_errorDescription_invalidResponse() {
+        XCTAssertEqual(LoadError.invalidResponse.errorDescription, "The server returned an invalid response.")
+    }
+
+    // MARK: - description
+
+    func test_description_notPresent() {
+        XCTAssertEqual(LoadError.notPresent.description, "Turbo Not Present")
+    }
+
+    func test_description_notReady() {
+        XCTAssertEqual(LoadError.notReady.description, "Turbo Not Ready")
+    }
+
+    func test_description_contentTypeMismatch() {
+        XCTAssertEqual(LoadError.contentTypeMismatch.description, "Content Type Mismatch")
+    }
+
+    func test_description_invalidResponse() {
+        XCTAssertEqual(LoadError.invalidResponse.description, "Invalid Response")
     }
 }

--- a/Tests/Turbo/LoadErrorTests.swift
+++ b/Tests/Turbo/LoadErrorTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import HotwireNative
+
+class LoadErrorTests: XCTestCase {
+
+    func test_errorDescriptions() {
+        let cases: [(LoadError, String)] = [
+            (.notPresent, "The page could not be loaded due to a configuration error."),
+            (.notReady, "The page could not be loaded due to a configuration error."),
+            (.contentTypeMismatch, "The server returned an invalid content type."),
+            (.invalidResponse, "The server returned an invalid response."),
+        ]
+
+        for (error, expected) in cases {
+            XCTAssertEqual(error.errorDescription, expected)
+        }
+    }
+}

--- a/Tests/Turbo/WebErrorTests.swift
+++ b/Tests/Turbo/WebErrorTests.swift
@@ -1,21 +1,24 @@
 import XCTest
 @testable import HotwireNative
 
-class WebErrorTests: XCTestCase {
+final class WebErrorTests: XCTestCase {
 
     // MARK: - isOffline
 
-    func test_isOffline_true_forOfflineURLErrors() {
-        let offlineCodes: [URLError.Code] = [.notConnectedToInternet, .networkConnectionLost]
-        for code in offlineCodes {
-            let error = WebError(urlError: URLError(code))
-            XCTAssertTrue(error.isOffline, "\(code) should be offline")
-        }
+    func test_isOffline_true_forNotConnectedToInternet() {
+        XCTAssertTrue(WebError(urlError: URLError(.notConnectedToInternet)).isOffline)
     }
 
-    func test_isOffline_false_forNonOfflineErrors() {
+    func test_isOffline_true_forNetworkConnectionLost() {
+        XCTAssertTrue(WebError(urlError: URLError(.networkConnectionLost)).isOffline)
+    }
+
+    func test_isOffline_false_forTimedOut() {
         XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isOffline)
-        XCTAssertFalse(WebError(errorCode: 0, description: nil).isOffline, "Turbo.js errors have no URLError")
+    }
+
+    func test_isOffline_false_whenNoURLError() {
+        XCTAssertFalse(WebError(errorCode: 0, description: nil).isOffline)
     }
 
     // MARK: - isTimeout
@@ -25,75 +28,159 @@ class WebErrorTests: XCTestCase {
     }
 
     func test_isTimeout_true_forTurboJSTimeoutCode() {
-        // Turbo.js SystemStatusCode.timeoutFailure = -1
         XCTAssertTrue(WebError(errorCode: -1, description: "Timeout").isTimeout)
     }
 
-    func test_isTimeout_false_forOtherErrors() {
+    func test_isTimeout_true_forRawTimedOutErrorCode() {
+        // URLError.Code.timedOut.rawValue is -1001. The isTimeout check uses errorCode directly,
+        // so a WebError constructed without a URLError but with -1001 should still be a timeout.
+        XCTAssertTrue(WebError(errorCode: -1001, description: nil).isTimeout)
+    }
+
+    func test_isTimeout_false_forNotConnectedToInternet() {
         XCTAssertFalse(WebError(urlError: URLError(.notConnectedToInternet)).isTimeout)
+    }
+
+    func test_isTimeout_false_forArbitraryErrorCode() {
+        XCTAssertFalse(WebError(errorCode: 0, description: nil).isTimeout)
     }
 
     // MARK: - isConnectionError
 
-    func test_isConnectionError_true_forHostErrors() {
-        let connectionCodes: [URLError.Code] = [.cannotFindHost, .cannotConnectToHost, .dnsLookupFailed]
-        for code in connectionCodes {
-            let error = WebError(urlError: URLError(code))
-            XCTAssertTrue(error.isConnectionError, "\(code) should be a connection error")
-        }
+    func test_isConnectionError_true_forCannotFindHost() {
+        XCTAssertTrue(WebError(urlError: URLError(.cannotFindHost)).isConnectionError)
+    }
+
+    func test_isConnectionError_true_forCannotConnectToHost() {
+        XCTAssertTrue(WebError(urlError: URLError(.cannotConnectToHost)).isConnectionError)
+    }
+
+    func test_isConnectionError_true_forDnsLookupFailed() {
+        XCTAssertTrue(WebError(urlError: URLError(.dnsLookupFailed)).isConnectionError)
     }
 
     func test_isConnectionError_false_whenNoURLError() {
         XCTAssertFalse(WebError(errorCode: 0, description: nil).isConnectionError)
     }
 
-    // MARK: - isSslError
-
-    func test_isSslError_true_forSslURLErrors() {
-        let sslCodes: [URLError.Code] = [
-            .secureConnectionFailed,
-            .serverCertificateUntrusted,
-            .serverCertificateHasUnknownRoot,
-            .clientCertificateRejected,
-        ]
-        for code in sslCodes {
-            let error = WebError(urlError: URLError(code))
-            XCTAssertTrue(error.isSslError, "\(code) should be an SSL error")
-        }
+    func test_isConnectionError_false_forTimedOut() {
+        XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isConnectionError)
     }
 
-    func test_isSslError_false_forNonSslError() {
+    // MARK: - isSslError
+
+    func test_isSslError_true_forSecureConnectionFailed() {
+        XCTAssertTrue(WebError(urlError: URLError(.secureConnectionFailed)).isSslError)
+    }
+
+    func test_isSslError_true_forServerCertificateHasBadDate() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateHasBadDate)).isSslError)
+    }
+
+    func test_isSslError_true_forServerCertificateUntrusted() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateUntrusted)).isSslError)
+    }
+
+    func test_isSslError_true_forServerCertificateHasUnknownRoot() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateHasUnknownRoot)).isSslError)
+    }
+
+    func test_isSslError_true_forServerCertificateNotYetValid() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateNotYetValid)).isSslError)
+    }
+
+    func test_isSslError_true_forClientCertificateRejected() {
+        XCTAssertTrue(WebError(urlError: URLError(.clientCertificateRejected)).isSslError)
+    }
+
+    func test_isSslError_true_forClientCertificateRequired() {
+        XCTAssertTrue(WebError(urlError: URLError(.clientCertificateRequired)).isSslError)
+    }
+
+    func test_isSslError_false_forTimedOut() {
         XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isSslError)
     }
 
-    // MARK: - Error Descriptions
-
-    func test_errorDescription_forURLErrors() {
-        let cases: [(URLError.Code, String)] = [
-            (.notConnectedToInternet, "Could not connect to the server."),
-            (.cannotFindHost, "Could not connect to the server."),
-            (.timedOut, "The request timed out."),
-            (.secureConnectionFailed, "A secure connection could not be established."),
-            (.httpTooManyRedirects, "Too many redirects occurred."),
-            (.badURL, "The URL is invalid."),
-        ]
-
-        for (code, expected) in cases {
-            let error = WebError(urlError: URLError(code))
-            XCTAssertEqual(error.errorDescription, expected, "URLError.\(code) should produce: \(expected)")
-        }
+    func test_isSslError_false_whenNoURLError() {
+        XCTAssertFalse(WebError(errorCode: 0, description: nil).isSslError)
     }
 
-    func test_errorDescription_fallsBackToURLErrorDescription_forUnhandledCodes() {
-        // URLError codes not specifically handled (e.g., .dataNotAllowed) fall through
-        // to urlError.localizedDescription
+    // MARK: - Cross-Classification
+
+    func test_offlineError_isNotTimeout() {
+        let error = WebError(urlError: URLError(.notConnectedToInternet))
+        XCTAssertTrue(error.isOffline)
+        XCTAssertFalse(error.isTimeout)
+        XCTAssertFalse(error.isConnectionError)
+        XCTAssertFalse(error.isSslError)
+    }
+
+    func test_connectionError_isNotOffline() {
+        let error = WebError(urlError: URLError(.cannotFindHost))
+        XCTAssertTrue(error.isConnectionError)
+        XCTAssertFalse(error.isOffline)
+        XCTAssertFalse(error.isTimeout)
+        XCTAssertFalse(error.isSslError)
+    }
+
+    func test_sslError_isNotConnectionError() {
+        let error = WebError(urlError: URLError(.secureConnectionFailed))
+        XCTAssertTrue(error.isSslError)
+        XCTAssertFalse(error.isOffline)
+        XCTAssertFalse(error.isTimeout)
+        XCTAssertFalse(error.isConnectionError)
+    }
+
+    // MARK: - errorDescription
+
+    func test_errorDescription_forNotConnectedToInternet() {
+        XCTAssertEqual(
+            WebError(urlError: URLError(.notConnectedToInternet)).errorDescription,
+            "Could not connect to the server."
+        )
+    }
+
+    func test_errorDescription_forCannotFindHost() {
+        XCTAssertEqual(
+            WebError(urlError: URLError(.cannotFindHost)).errorDescription,
+            "Could not connect to the server."
+        )
+    }
+
+    func test_errorDescription_forTimedOut() {
+        XCTAssertEqual(
+            WebError(urlError: URLError(.timedOut)).errorDescription,
+            "The request timed out."
+        )
+    }
+
+    func test_errorDescription_forSecureConnectionFailed() {
+        XCTAssertEqual(
+            WebError(urlError: URLError(.secureConnectionFailed)).errorDescription,
+            "A secure connection could not be established."
+        )
+    }
+
+    func test_errorDescription_forHttpTooManyRedirects() {
+        XCTAssertEqual(
+            WebError(urlError: URLError(.httpTooManyRedirects)).errorDescription,
+            "Too many redirects occurred."
+        )
+    }
+
+    func test_errorDescription_forBadURL() {
+        XCTAssertEqual(
+            WebError(urlError: URLError(.badURL)).errorDescription,
+            "The URL is invalid."
+        )
+    }
+
+    func test_errorDescription_forUnhandledURLError_fallsBackToSystemDescription() {
         let error = WebError(urlError: URLError(.dataNotAllowed))
-        XCTAssertNotNil(error.errorDescription)
-        XCTAssertNotEqual(error.errorDescription, "Could not connect to the server.")
-        XCTAssertNotEqual(error.errorDescription, "The request timed out.")
+        XCTAssertEqual(error.errorDescription, URLError(.dataNotAllowed).localizedDescription)
     }
 
-    func test_errorDescription_fallsBackToDescription_whenNoURLError() {
+    func test_errorDescription_usesStoredDescription_whenNoURLError() {
         let error = WebError(errorCode: 0, description: "Network failure")
         XCTAssertEqual(error.errorDescription, "Network failure")
     }
@@ -103,21 +190,22 @@ class WebErrorTests: XCTestCase {
         XCTAssertEqual(error.errorDescription, "Network Error")
     }
 
-    // MARK: - Factory: from URLError
+    // MARK: - from(URLError)
 
-    func test_from_urlError_preservesURLError() {
+    func test_from_urlError_preservesURLErrorAndCode() {
         let urlError = URLError(.notConnectedToInternet)
         let webError = WebError.from(urlError)
         XCTAssertEqual(webError.urlError, urlError)
         XCTAssertEqual(webError.errorCode, URLError.Code.notConnectedToInternet.rawValue)
     }
 
-    // MARK: - Factory: from generic Error
+    // MARK: - from(Error)
 
     func test_from_genericError_extractsURLError() {
         let urlError = URLError(.timedOut)
         let webError = WebError.from(urlError as Error)
         XCTAssertEqual(webError.urlError, urlError)
+        XCTAssertEqual(webError.errorCode, URLError.Code.timedOut.rawValue)
     }
 
     func test_from_genericError_wrapsNonURLError() {
@@ -127,24 +215,25 @@ class WebErrorTests: XCTestCase {
         XCTAssertEqual(webError.errorCode, 42)
     }
 
-    // MARK: - Factory: from Turbo.js status code
+    // MARK: - Initializers
 
-    func test_from_turboStatusCode_zero_isNetworkFailure() {
-        let webError = WebError.from(turboStatusCode: 0)
-        XCTAssertEqual(webError.errorCode, 0)
-        XCTAssertNil(webError.urlError)
+    func test_init_urlError_setsAllProperties() {
+        let urlError = URLError(.notConnectedToInternet)
+        let webError = WebError(urlError: urlError)
+        XCTAssertEqual(webError.urlError, urlError)
+        XCTAssertEqual(webError.errorCode, urlError.code.rawValue)
+        XCTAssertEqual(webError.description, urlError.localizedDescription)
     }
 
-    func test_from_turboStatusCode_negative1_isTimeout() {
-        let webError = WebError.from(turboStatusCode: -1)
-        XCTAssertTrue(webError.isTimeout)
-        XCTAssertEqual(webError.errorCode, -1)
+    func test_init_errorCode_setsAllProperties() {
+        let webError = WebError(errorCode: 42, description: "Custom")
+        XCTAssertNil(webError.urlError)
+        XCTAssertEqual(webError.errorCode, 42)
+        XCTAssertEqual(webError.description, "Custom")
     }
 
-    func test_from_turboStatusCode_unknownNegative_defaultsToNetworkError() {
-        let webError = WebError.from(turboStatusCode: -99)
-        XCTAssertEqual(webError.errorCode, -99)
-        XCTAssertNil(webError.urlError)
-        XCTAssertNotNil(webError.errorDescription)
+    func test_init_errorCode_nilDescription_defaultsToNetworkError() {
+        let webError = WebError(errorCode: 0, description: nil)
+        XCTAssertEqual(webError.description, "Network Error")
     }
 }

--- a/Tests/Turbo/WebErrorTests.swift
+++ b/Tests/Turbo/WebErrorTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import HotwireNative
+
+class WebErrorTests: XCTestCase {
+
+    // MARK: - isOffline
+
+    func test_isOffline_true_forOfflineURLErrors() {
+        let offlineCodes: [URLError.Code] = [.notConnectedToInternet, .networkConnectionLost]
+        for code in offlineCodes {
+            let error = WebError(urlError: URLError(code))
+            XCTAssertTrue(error.isOffline, "\(code) should be offline")
+        }
+    }
+
+    func test_isOffline_false_forNonOfflineErrors() {
+        XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isOffline)
+        XCTAssertFalse(WebError(errorCode: 0, description: nil).isOffline, "Turbo.js errors have no URLError")
+    }
+
+    // MARK: - isTimeout
+
+    func test_isTimeout_true_forURLErrorTimedOut() {
+        XCTAssertTrue(WebError(urlError: URLError(.timedOut)).isTimeout)
+    }
+
+    func test_isTimeout_true_forTurboJSTimeoutCode() {
+        // Turbo.js SystemStatusCode.timeoutFailure = -1
+        XCTAssertTrue(WebError(errorCode: -1, description: "Timeout").isTimeout)
+    }
+
+    func test_isTimeout_false_forOtherErrors() {
+        XCTAssertFalse(WebError(urlError: URLError(.notConnectedToInternet)).isTimeout)
+    }
+
+    // MARK: - isConnectionError
+
+    func test_isConnectionError_true_forHostErrors() {
+        let connectionCodes: [URLError.Code] = [.cannotFindHost, .cannotConnectToHost, .dnsLookupFailed]
+        for code in connectionCodes {
+            let error = WebError(urlError: URLError(code))
+            XCTAssertTrue(error.isConnectionError, "\(code) should be a connection error")
+        }
+    }
+
+    func test_isConnectionError_false_whenNoURLError() {
+        XCTAssertFalse(WebError(errorCode: 0, description: nil).isConnectionError)
+    }
+
+    // MARK: - isSslError
+
+    func test_isSslError_true_forSslURLErrors() {
+        let sslCodes: [URLError.Code] = [
+            .secureConnectionFailed,
+            .serverCertificateUntrusted,
+            .serverCertificateHasUnknownRoot,
+            .clientCertificateRejected,
+        ]
+        for code in sslCodes {
+            let error = WebError(urlError: URLError(code))
+            XCTAssertTrue(error.isSslError, "\(code) should be an SSL error")
+        }
+    }
+
+    func test_isSslError_false_forNonSslError() {
+        XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isSslError)
+    }
+
+    // MARK: - Error Descriptions
+
+    func test_errorDescription_forURLErrors() {
+        let cases: [(URLError.Code, String)] = [
+            (.notConnectedToInternet, "Could not connect to the server."),
+            (.cannotFindHost, "Could not connect to the server."),
+            (.timedOut, "The request timed out."),
+            (.secureConnectionFailed, "A secure connection could not be established."),
+            (.httpTooManyRedirects, "Too many redirects occurred."),
+            (.badURL, "The URL is invalid."),
+        ]
+
+        for (code, expected) in cases {
+            let error = WebError(urlError: URLError(code))
+            XCTAssertEqual(error.errorDescription, expected, "URLError.\(code) should produce: \(expected)")
+        }
+    }
+
+    func test_errorDescription_fallsBackToURLErrorDescription_forUnhandledCodes() {
+        // URLError codes not specifically handled (e.g., .dataNotAllowed) fall through
+        // to urlError.localizedDescription
+        let error = WebError(urlError: URLError(.dataNotAllowed))
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertNotEqual(error.errorDescription, "Could not connect to the server.")
+        XCTAssertNotEqual(error.errorDescription, "The request timed out.")
+    }
+
+    func test_errorDescription_fallsBackToDescription_whenNoURLError() {
+        let error = WebError(errorCode: 0, description: "Network failure")
+        XCTAssertEqual(error.errorDescription, "Network failure")
+    }
+
+    func test_errorDescription_defaultsToNetworkError_whenDescriptionIsNil() {
+        let error = WebError(errorCode: 0, description: nil)
+        XCTAssertEqual(error.errorDescription, "Network Error")
+    }
+
+    // MARK: - Factory: from URLError
+
+    func test_from_urlError_preservesURLError() {
+        let urlError = URLError(.notConnectedToInternet)
+        let webError = WebError.from(urlError)
+        XCTAssertEqual(webError.urlError, urlError)
+        XCTAssertEqual(webError.errorCode, URLError.Code.notConnectedToInternet.rawValue)
+    }
+
+    // MARK: - Factory: from generic Error
+
+    func test_from_genericError_extractsURLError() {
+        let urlError = URLError(.timedOut)
+        let webError = WebError.from(urlError as Error)
+        XCTAssertEqual(webError.urlError, urlError)
+    }
+
+    func test_from_genericError_wrapsNonURLError() {
+        let nsError = NSError(domain: "test", code: 42)
+        let webError = WebError.from(nsError as Error)
+        XCTAssertNil(webError.urlError)
+        XCTAssertEqual(webError.errorCode, 42)
+    }
+
+    // MARK: - Factory: from Turbo.js status code
+
+    func test_from_turboStatusCode_zero_isNetworkFailure() {
+        let webError = WebError.from(turboStatusCode: 0)
+        XCTAssertEqual(webError.errorCode, 0)
+        XCTAssertNil(webError.urlError)
+    }
+
+    func test_from_turboStatusCode_negative1_isTimeout() {
+        let webError = WebError.from(turboStatusCode: -1)
+        XCTAssertTrue(webError.isTimeout)
+        XCTAssertEqual(webError.errorCode, -1)
+    }
+
+    func test_from_turboStatusCode_unknownNegative_defaultsToNetworkError() {
+        let webError = WebError.from(turboStatusCode: -99)
+        XCTAssertEqual(webError.errorCode, -99)
+        XCTAssertNil(webError.urlError)
+        XCTAssertNotNil(webError.errorDescription)
+    }
+}

--- a/Tests/Turbo/WebErrorTests.swift
+++ b/Tests/Turbo/WebErrorTests.swift
@@ -67,42 +67,42 @@ final class WebErrorTests: XCTestCase {
         XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isConnectionError)
     }
 
-    // MARK: - isSslError
+    // MARK: - isSSLError
 
-    func test_isSslError_true_forSecureConnectionFailed() {
-        XCTAssertTrue(WebError(urlError: URLError(.secureConnectionFailed)).isSslError)
+    func test_isSSLError_true_forSecureConnectionFailed() {
+        XCTAssertTrue(WebError(urlError: URLError(.secureConnectionFailed)).isSSLError)
     }
 
-    func test_isSslError_true_forServerCertificateHasBadDate() {
-        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateHasBadDate)).isSslError)
+    func test_isSSLError_true_forServerCertificateHasBadDate() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateHasBadDate)).isSSLError)
     }
 
-    func test_isSslError_true_forServerCertificateUntrusted() {
-        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateUntrusted)).isSslError)
+    func test_isSSLError_true_forServerCertificateUntrusted() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateUntrusted)).isSSLError)
     }
 
-    func test_isSslError_true_forServerCertificateHasUnknownRoot() {
-        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateHasUnknownRoot)).isSslError)
+    func test_isSSLError_true_forServerCertificateHasUnknownRoot() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateHasUnknownRoot)).isSSLError)
     }
 
-    func test_isSslError_true_forServerCertificateNotYetValid() {
-        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateNotYetValid)).isSslError)
+    func test_isSSLError_true_forServerCertificateNotYetValid() {
+        XCTAssertTrue(WebError(urlError: URLError(.serverCertificateNotYetValid)).isSSLError)
     }
 
-    func test_isSslError_true_forClientCertificateRejected() {
-        XCTAssertTrue(WebError(urlError: URLError(.clientCertificateRejected)).isSslError)
+    func test_isSSLError_true_forClientCertificateRejected() {
+        XCTAssertTrue(WebError(urlError: URLError(.clientCertificateRejected)).isSSLError)
     }
 
-    func test_isSslError_true_forClientCertificateRequired() {
-        XCTAssertTrue(WebError(urlError: URLError(.clientCertificateRequired)).isSslError)
+    func test_isSSLError_true_forClientCertificateRequired() {
+        XCTAssertTrue(WebError(urlError: URLError(.clientCertificateRequired)).isSSLError)
     }
 
-    func test_isSslError_false_forTimedOut() {
-        XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isSslError)
+    func test_isSSLError_false_forTimedOut() {
+        XCTAssertFalse(WebError(urlError: URLError(.timedOut)).isSSLError)
     }
 
-    func test_isSslError_false_whenNoURLError() {
-        XCTAssertFalse(WebError(errorCode: 0, description: nil).isSslError)
+    func test_isSSLError_false_whenNoURLError() {
+        XCTAssertFalse(WebError(errorCode: 0, description: nil).isSSLError)
     }
 
     // MARK: - Cross-Classification
@@ -112,7 +112,7 @@ final class WebErrorTests: XCTestCase {
         XCTAssertTrue(error.isOffline)
         XCTAssertFalse(error.isTimeout)
         XCTAssertFalse(error.isConnectionError)
-        XCTAssertFalse(error.isSslError)
+        XCTAssertFalse(error.isSSLError)
     }
 
     func test_connectionError_isNotOffline() {
@@ -120,12 +120,12 @@ final class WebErrorTests: XCTestCase {
         XCTAssertTrue(error.isConnectionError)
         XCTAssertFalse(error.isOffline)
         XCTAssertFalse(error.isTimeout)
-        XCTAssertFalse(error.isSslError)
+        XCTAssertFalse(error.isSSLError)
     }
 
     func test_sslError_isNotConnectionError() {
         let error = WebError(urlError: URLError(.secureConnectionFailed))
-        XCTAssertTrue(error.isSslError)
+        XCTAssertTrue(error.isSSLError)
         XCTAssertFalse(error.isOffline)
         XCTAssertFalse(error.isTimeout)
         XCTAssertFalse(error.isConnectionError)


### PR DESCRIPTION
/## Summary                        
                                               
  Adds test coverage for the four error types introduced in #215: `HotwireNativeError`, `HttpError`, `WebError`, and `LoadError`.

  - **38 test methods** covering ~85 assertions across 4 test files (one per source file)
  - Tests are grounded in actual [Turbo.js `SystemStatusCode` values](https://github.com/hotwired/turbo/blob/main/src/core/drive/visit.js) (`0`, `-1`, `-2`) and the real flow from
  `visitRequestFailedWithStatusCode` through the iOS native adapter

  ## What's covered

  | Area | What's tested |
  |------|---------------|
  | **`HotwireNativeError`** | Turbo.js SystemStatusCode mapping (0, -1, -2), HTTP codes via `visitRequestFailed`, unknown 4xx/5xx falling to `.other`, unexpected codes (negative, 1xx, 3xx), `.statusCode` and
  `.urlError` convenience properties, error description delegation |
  | **`HttpError`** | Status code range boundaries (399/400/499/500/599/600), round-trip for all 14 `ClientError` and 6 `ServerError` named cases, unmapped codes falling to `.other`, error descriptions |
  | **`WebError`** | `isOffline`, `isTimeout`, `isConnectionError`, `isSslError` classification helpers (positive and negative cases), all `errorDescription` branches including the unhandled-URLError fallback,
  `from(URLError)`, `from(Error)`, and `from(turboStatusCode:)` factories |
  | **`LoadError`** | All 4 case error descriptions |

  ## Test design decisions

- **Table-driven tests** where multiple inputs exercise the same logic, with descriptive failure messages
- **Unknown vs. unexpected** distinction: "unknown" = valid HTTP codes the enum doesn't name (410, 418, 451) mapping to `.other`; "unexpected" = codes that shouldn't arrive through Turbo.js (like -3, 100, 301) testing defensive fallback
- **One test file per source file** matching the existing `Tests/Turbo/` organization
- **XCTest** to match the project's existing test conventions