### PR TITLE
Cancel leaked WKWebView navigations in test simulator

### DIFF
--- a/Tests/Turbo/WebViewPolicy/BaseWebViewPolicyDecisionHandlerTests.swift
+++ b/Tests/Turbo/WebViewPolicy/BaseWebViewPolicyDecisionHandlerTests.swift
@@ -17,6 +17,7 @@ class BaseWebViewPolicyDecisionHandlerTests: XCTestCase {
     }
 
     override func tearDown() async throws {
+        webNavigationSimulator.stopLoading()
         webNavigationSimulator = nil
     }
 }

--- a/Tests/Turbo/WebViewPolicy/WebViewNavigationSimulator.swift
+++ b/Tests/Turbo/WebViewPolicy/WebViewNavigationSimulator.swift
@@ -49,12 +49,26 @@ class WebViewNavigationSimulator: NSObject, WKNavigationDelegate {
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         capturedNavigationAction = navigationAction
-        decisionHandler(.allow)
-        
+
         // When there is no simulated click, or after a simulated click is performed, resume the continuation.
-        if simulateLinkClickElementId == nil || didSimulateLinkClick {
+        let shouldResumeContinuation = simulateLinkClickElementId == nil || didSimulateLinkClick
+
+        if shouldResumeContinuation {
+            // Cancel the actual navigation — we only need the WKNavigationAction object.
+            // Allowing it would let WKWebView navigate to external URLs (e.g., https://example.com),
+            // blocking the shared WKProcessPool and stalling subsequent tests for minutes.
+            decisionHandler(.cancel)
             continuation?.resume(returning: navigationAction)
             continuation = nil
+        } else {
+            // Allow intermediate navigations (e.g., the initial loadHTMLString page load)
+            // so the page fully loads and didFinish can trigger the simulated click.
+            decisionHandler(.allow)
         }
+    }
+
+    func stopLoading() {
+        webView.stopLoading()
+        webView.navigationDelegate = nil
     }
 }

--- a/Tests/Turbo/WebViewPolicy/WebViewPolicyManagerTests.swift
+++ b/Tests/Turbo/WebViewPolicy/WebViewPolicyManagerTests.swift
@@ -30,6 +30,7 @@ final class WebViewPolicyManagerTests: XCTestCase {
     }
 
     override func tearDown() async throws {
+        webNavigationSimulator?.stopLoading()
         webNavigationSimulator = nil
     }
 


### PR DESCRIPTION
## Summary

- `WebViewNavigationSimulator.decidePolicyFor` always called `decisionHandler(.allow)`, which let WKWebView actually navigate to `https://example.com` over the real network after capturing the `WKNavigationAction`. This blocked WebKit's shared `WKProcessPool` and stalled subsequent tests for 12+ minutes in CI.
- Now calls `.cancel` once the `WKNavigationAction` is captured (which is all the tests need), and `.allow` only for intermediate navigations that must complete (e.g., the initial `loadHTMLString` page load)
- Adds `stopLoading()` cleanup in `tearDown` as a safety net

### Before & after (local run, 208 tests on `main`)

| Test | Before | After |
|------|--------|-------|
| `test_handling_link_activated_...` | **759s** | **0.77s** |
| `BridgeComponentAsyncAPITests.test_didReceiveCachesTheMessage` | **137s** | **7.2s** |
| `BridgeComponentAsyncAPITests.test_replyToMessageNotReceived...` | **18s** | **0.66s** |
| **Total suite** | **~1018s** | **~52s** |

## Test plan

- [x] Full test suite passes locally (208 tests, 0 failures)
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)