### PR TITLE
Fix: Unhandled completion handlers cause crashes when delegate is deallocated

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -222,7 +222,11 @@ extension Navigator: SessionDelegate {
     }
 
     public func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        delegate?.didReceiveAuthenticationChallenge(challenge, completionHandler: completionHandler)
+        guard let delegate else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        delegate.didReceiveAuthenticationChallenge(challenge, completionHandler: completionHandler)
     }
 
     public func sessionDidFinishRequest(_ session: Session) {

--- a/Source/Turbo/Navigator/WKUIController.swift
+++ b/Source/Turbo/Navigator/WKUIController.swift
@@ -13,14 +13,22 @@ open class WKUIController: NSObject, WKUIDelegate {
     }
 
     open func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
+        guard let delegate else {
+            completionHandler()
+            return
+        }
         let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Close", style: .default) { _ in
             completionHandler()
         })
-        delegate?.present(alert, animated: true)
+        delegate.present(alert, animated: true)
     }
 
     open func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+        guard let delegate else {
+            completionHandler(false)
+            return
+        }
         let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
             completionHandler(true)
@@ -28,6 +36,6 @@ open class WKUIController: NSObject, WKUIDelegate {
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
             completionHandler(false)
         })
-        delegate?.present(alert, animated: true)
+        delegate.present(alert, animated: true)
     }
 }

--- a/Source/Turbo/Session/Session.swift
+++ b/Source/Turbo/Session/Session.swift
@@ -219,7 +219,11 @@ extension Session: VisitDelegate {
     }
 
     func visit(_ visit: Visit, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        delegate?.session(self, didReceiveAuthenticationChallenge: challenge, completionHandler: completionHandler)
+        guard let delegate else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        delegate.session(self, didReceiveAuthenticationChallenge: challenge, completionHandler: completionHandler)
     }
 
     func visitDidProposeVisitToLocation(_ location: URL) {

--- a/Source/Turbo/Visit/ColdBootVisit.swift
+++ b/Source/Turbo/Visit/ColdBootVisit.swift
@@ -128,7 +128,11 @@ extension ColdBootVisit: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        delegate?.visit(self, didReceiveAuthenticationChallenge: challenge, completionHandler: completionHandler)
+        guard let delegate else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        delegate.visit(self, didReceiveAuthenticationChallenge: challenge, completionHandler: completionHandler)
     }
 }
 


### PR DESCRIPTION
Hey! We're running a production app with quite a large user base and have been seeing a few rare but hard crashes traced back to these methods. After digging into the code I think I found the cause and put together a fix — happy to be corrected if I'm reading this wrong.

# The issue

Several `WKNavigationDelegate` / `WKUIDelegate` methods pass their mandatory completion handlers through an optional delegate chain. If the delegate has been deallocated by the time WebKit fires the callback, the optional chain silently does nothing, the handler is never called, and WebKit raises `NSInternalInconsistencyException` — crashing the entire app.

# Affected methods

**`ColdBootVisit` — `didReceiveAuthenticationChallenge`**

`ColdBootVisit.delegate` is a weak reference to `Session`. While `Session` strongly owns the `WKWebView`, but from what I gathered WebKit's network process can keep the web view alive independently during an in-flight request. If `Session` is torn down mid-cold-boot (e.g. during a navigator replacement), `ColdBootVisit` can outlive it just long enough for the challenge callback to arrive with a nil delegate.

Worth noting: this challenge apparently fires on the first HTTPS connection as part of standard TLS server trust evaluation, not just pages with HTTP auth (as I originally thought) — so the race can happen on any cold boot.

**`WKUIController` — `runJavaScriptConfirmPanelWithMessage` and `runJavaScriptAlertPanelWithMessage`**

`WKUIController` is strongly owned by `Navigator` via `webkitUIDelegate`, but `WKWebView.uiDelegate` holds it weakly. If `Navigator` is torn down while WebKit is simultaneously invoking one of these methods (WebKit temporarily retains the delegate during the call), `WKUIController.delegate` is nil, the alert is never presented, its actions never fire, and the handler is never called.

# Crash reports

**`ColdBootVisit`**
```
OS Version:     iOS 26.3 (23D127)
Hardware Model: iPhone17,1

Exception Type:     EXC_CRASH (SIGABRT)
Termination Reason: SIGNAL 6

NSInternalInconsistencyException:
Completion handler passed to -[HotwireNative.ColdBootVisit
webView:didReceiveAuthenticationChallenge:completionHandler:] was not called

Thread 0 Crashed:
0   CoreFoundation       objc_exception_throw
1   libobjc.A.dylib      objc_exception_throw + 88
2   CoreFoundation
3   WebKit
...
7   libsystem_blocks     _Block_release + 236   ← handler released uncalled
```

**`WKUIController`**
```
OS Version:     iOS 26.3 (23D127)
Hardware Model: iPhone15,4

Exception Type:     EXC_CRASH (SIGABRT)
Termination Reason: SIGNAL 6

NSInternalInconsistencyException:
Completion handler passed to -[HotwireNative.WKUIController
webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:] was not called

Thread 0 Crashed:
0   CoreFoundation       objc_exception_throw
1   libobjc.A.dylib      objc_exception_throw + 88
2   CoreFoundation
3   WebKit
...
7   libsystem_blocks     _Block_release + 236   ← handler released uncalled
8   clubcorner
9   libswiftCore.dylib
```

# The fix

The pattern is the same in all cases: guard on `delegate` and call the handler with a safe default if it's nil. For the auth challenge that's `.performDefaultHandling`, for the confirm panel `false` (mirrors the user cancelling), and for the alert panel just calling through. I also proactively fixed `runJavaScriptAlertPanelWithMessage` since it has the same pattern, even though we haven't seen it crash yet.