### PR TITLE
Fix refresh_historical_location restoring from snapshot cache

### DIFF
--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -253,9 +253,9 @@ extension Navigator: NavigationHierarchyControllerDelegate {
     func refreshVisitable(navigationStack: NavigationHierarchyController.NavigationStackType, newTopmostVisitable: any Visitable) {
         switch navigationStack {
         case .main:
-            session.visit(newTopmostVisitable, action: .restore)
+            session.visit(newTopmostVisitable, action: .replace)
         case .modal:
-            modalSession.visit(newTopmostVisitable, action: .restore)
+            modalSession.visit(newTopmostVisitable, action: .replace)
         }
     }
 }

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerHistoricalLocationTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerHistoricalLocationTests.swift
@@ -87,7 +87,7 @@ final class NavigationHierarchyControllerHistoricalLocationTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssertEqual(navigator.session.activeVisitable?.initialVisitableURL, defaultOne.url)
         XCTAssertTrue(session.visitWasCalled)
-        XCTAssertEqual(session.visitAction, .restore)
+        XCTAssertEqual(session.visitAction, .replace)
     }
 
     // Recede behaviour:


### PR DESCRIPTION
## Summary

- `refreshVisitable` in `Navigator.swift` was issuing `action: .restore`, which is Turbo's back-navigation action and prefers a cached snapshot when one exists. That contradicts the "refresh" intent expressed by `refresh_or_redirect_to` / `/refresh_historical_location`: after a non-safe form submission, the underlying page should reflect the new server state, not a snapshot taken before the mutation.
- Switched both branches of `refreshVisitable` to `action: .replace`, which re-fetches and renders the historical location in place without adding to history.

## Repro (before this fix)

1. Navigate from `/page_1` to `/page_2` (in any presentation that ends up using the snapshot cache).
2. Submit a non-safe form on `/page_2`; server returns `refresh_or_redirect_to /page_1` → `/refresh_historical_location`.
3. First submission appears correct only because the default session's snapshot cache happened to be empty.
4. Navigate to `/page_2` again, submit again. Now `/page_1` is rendered from the cached snapshot taken before the first mutation — new content is missing.

Bridge logs show `[Session] visit ... action=restore ... hasCachedSnapshot=1` on the second cycle, confirming the restore path is reusing the cached snapshot.

Related: hotwired/hotwire-native-ios#234.

## Test plan

- [x] Manual: reproduce the scenario above against an app using `refresh_or_redirect_to` (or any server-side redirect to `/refresh_historical_location`) and confirm `/page_1` shows fresh content on every refresh, not just the first.
- [x] Existing tests in `Tests/Turbo/Navigator/` still pass.