### PR TITLE
Stamp routed location on view controllers for navigation identity

### DIFF
--- a/Source/Turbo/Navigator/Extensions/UIViewController+RoutedLocation.swift
+++ b/Source/Turbo/Navigator/Extensions/UIViewController+RoutedLocation.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+private let routedLocationKey = malloc(1)!
+
+extension UIViewController {
+    /// The location the navigator routed this view controller to, stamped at route time by
+    /// `NavigationHierarchyController`. Navigation identity checks read this so two instances
+    /// of the same custom view-controller class at different URLs are distinguishable.
+    var routedLocation: URL? {
+        get { objc_getAssociatedObject(self, routedLocationKey) as? URL }
+        set { objc_setAssociatedObject(self, routedLocationKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+}

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -37,6 +37,8 @@ class NavigationHierarchyController {
         if let alert = controller as? UIAlertController {
             presentAlert(alert, via: proposal)
         } else {
+            controller.routedLocation = proposal.url
+
             if let visitable = controller as? Visitable {
                 visitable.visitableView.allowsPullToRefresh = proposal.pullToRefreshEnabled
             }
@@ -134,9 +136,9 @@ class NavigationHierarchyController {
                                with controller: UIViewController,
                                via proposal: VisitProposal,
                                didReplaceModalContext: Bool = false) {
-        if visitingSamePage(on: navigationController, with: controller, via: proposal) {
+        if visitingSamePage(on: navigationController, via: proposal) {
             navigationController.replaceLastViewController(with: controller)
-        } else if visitingPreviousPage(on: navigationController, with: controller, via: proposal) {
+        } else if visitingPreviousPage(on: navigationController, via: proposal) {
             navigationController.popViewController(animated: proposal.animated)
         } else if proposal.options.action == .advance || didReplaceModalContext {
             navigationController.pushViewController(controller, animated: proposal.animated)
@@ -145,27 +147,41 @@ class NavigationHierarchyController {
         }
     }
 
-    private func visitingSamePage(on navigationController: UINavigationController,
-                                  with controller: UIViewController,
-                                  via proposal: VisitProposal) -> Bool {
-        if let visitable = navigationController.topViewController as? Visitable {
-            return visitable.initialVisitableURL.isSameLocation(as: proposal.url, pathProperties: proposal.properties)
-        } else if let topViewController = navigationController.topViewController {
-            return topViewController.isMember(of: type(of: controller))
+    private func visitingSamePage(
+        on navigationController: UINavigationController,
+        via proposal: VisitProposal
+    ) -> Bool {
+        guard let topViewController = navigationController.topViewController else { return false }
+
+        guard let location = topViewController.routedLocation else {
+            assertionFailure("Top view controller \(topViewController) has no routed location. " +
+                             "Controllers placed on the navigator's stack must be routed through it; treating the visit as a new page.")
+            return false
         }
-        return false
+
+        return location.isSameLocation(
+            as: proposal.url,
+            pathProperties: proposal.properties
+        )
     }
 
-    private func visitingPreviousPage(on navigationController: UINavigationController,
-                                      with controller: UIViewController,
-                                      via proposal: VisitProposal) -> Bool {
+    private func visitingPreviousPage(
+        on navigationController: UINavigationController,
+        via proposal: VisitProposal
+    ) -> Bool {
         guard navigationController.viewControllers.count >= 2 else { return false }
 
         let previousController = navigationController.viewControllers[navigationController.viewControllers.count - 2]
-        if let previousVisitable = previousController as? VisitableViewController {
-            return previousVisitable.initialVisitableURL.isSameLocation(as: proposal.url, pathProperties: proposal.properties)
+        guard let location = previousController.routedLocation else {
+            assertionFailure("Previous view controller \(previousController) has no routed location. " +
+                             "Controllers placed on the navigator's stack must be routed through it; treating the visit as a new page.")
+            return false
         }
-        return type(of: previousController) == type(of: controller)
+
+        return location.isSameLocation(
+            as: proposal.url,
+            pathProperties: proposal.properties
+        )
     }
 
     private func replace(with controller: UIViewController, via proposal: VisitProposal) {

--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -154,8 +154,8 @@ class NavigationHierarchyController {
         guard let topViewController = navigationController.topViewController else { return false }
 
         guard let location = topViewController.routedLocation else {
-            assertionFailure("Top view controller \(topViewController) has no routed location. " +
-                             "Controllers placed on the navigator's stack must be routed through it; treating the visit as a new page.")
+            logger.warning("Top view controller \(topViewController) has no routed location; " +
+                           "treating the visit as a new page. Expected for controllers pushed onto the stack outside the navigator.")
             return false
         }
 
@@ -173,8 +173,8 @@ class NavigationHierarchyController {
 
         let previousController = navigationController.viewControllers[navigationController.viewControllers.count - 2]
         guard let location = previousController.routedLocation else {
-            assertionFailure("Previous view controller \(previousController) has no routed location. " +
-                             "Controllers placed on the navigator's stack must be routed through it; treating the visit as a new page.")
+            logger.warning("Previous view controller \(previousController) has no routed location; " +
+                           "treating the visit as a new page. Expected for controllers pushed onto the stack outside the navigator.")
             return false
         }
 

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -83,6 +83,41 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         assertVisited(url: oneURL, on: .main)
     }
 
+    func test_customViewController_visitingDifferentURL_pushesOnMainStack() {
+        let navigator = makeCustomViewControllerNavigator()
+
+        navigator.route(oneURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssert(navigationController.topViewController is CustomViewController)
+
+        navigator.route(twoURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssert(navigationController.topViewController is CustomViewController)
+    }
+
+    func test_customViewController_visitingSameURL_replacesOnMainStack() {
+        let navigator = makeCustomViewControllerNavigator()
+
+        navigator.route(oneURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+
+        navigator.route(oneURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssert(navigationController.topViewController is CustomViewController)
+    }
+
+    func test_customViewController_visitingPreviousURL_popsOnMainStack() {
+        let navigator = makeCustomViewControllerNavigator()
+
+        navigator.route(oneURL)
+        navigator.route(twoURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+
+        navigator.route(oneURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssert(navigationController.topViewController is CustomViewController)
+    }
+
     func test_default_default_default_replaceAction_replacesOnMainStack() {
         let proposal = VisitProposal(action: .replace)
         navigator.route(proposal)
@@ -188,7 +223,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
     }
 
     func test_modal_default_default_dismissesModalThenPushesOnMainStack() {
-        navigationController.pushViewController(UIViewController(), animated: false)
+        navigationController.pushViewController(routedViewController(url: baseURL.appendingPathComponent("/existing")), animated: false)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
 
         navigator.route(VisitProposal(context: .modal))
@@ -327,7 +362,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
     }
 
     func test_default_any_pop_popsOffMainStack() {
-        navigationController.pushViewController(UIViewController(), animated: false)
+        navigationController.pushViewController(routedViewController(url: baseURL.appendingPathComponent("/existing")), animated: false)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
 
         navigator.route(VisitProposal())
@@ -482,11 +517,38 @@ final class NavigationHierarchyControllerTests: XCTestCase {
 
     private var navigator: Navigator!
     private let alertControllerDelegate = AlertControllerDelegate()
+    // `Navigator.delegate` is weak, so the test must hold a strong reference.
+    private let customViewControllerDelegate = CustomViewControllerDelegate()
     private var hierarchyController: NavigationHierarchyController!
     private var navigationController: TestableNavigationController!
     private var modalNavigationController: TestableNavigationController!
 
     private let window = UIWindow()
+
+    // A navigator whose delegate routes custom, non-`Visitable` view controllers, wired to the
+    // same navigation controllers the test asserts against.
+    private func makeCustomViewControllerNavigator() -> Navigator {
+        let navigator = Navigator(
+            session: session,
+            modalSession: modalSession,
+            delegate: customViewControllerDelegate,
+            configuration: .init(name: "Test", startLocation: oneURL)
+        )
+        navigator.hierarchyController = NavigationHierarchyController(
+            delegate: navigator,
+            navigationController: navigationController,
+            modalNavigationController: modalNavigationController
+        )
+        return navigator
+    }
+
+    // A view controller stamped with a routed location, standing in for a screen the navigator
+    // has already routed. Identity checks require every stack member to have a location.
+    private func routedViewController(url: URL) -> UIViewController {
+        let viewController = UIViewController()
+        viewController.routedLocation = url
+        return viewController
+    }
 
     // Simulate a "real" app so presenting view controllers works under test.
     private func loadNavigationControllerInWindow() {
@@ -546,5 +608,17 @@ private class AlertControllerDelegate: NavigatorDelegate {
         }
 
         return .accept
+    }
+}
+
+// MARK: - CustomViewControllerDelegate
+
+/// A non-`Visitable` custom view controller. Two instances at different URLs share a type, so
+/// the navigator must rely on the stamped routed location — not type equality — to tell them apart.
+private final class CustomViewController: UIViewController {}
+
+private class CustomViewControllerDelegate: NavigatorDelegate {
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
+        .acceptCustom(CustomViewController())
     }
 }

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -118,6 +118,20 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         XCTAssert(navigationController.topViewController is CustomViewController)
     }
 
+    func test_unroutedViewController_onStack_visitPushesOnMainStack() {
+        // A view controller pushed onto the stack outside the navigator (e.g. mixed native
+        // navigation) has no routed location. A subsequent visit must treat it as a new page
+        // and push — never crash or incorrectly replace/pop.
+        navigationController.pushViewController(UIViewController(), animated: false)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+
+        navigator.route(oneURL)
+
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssert(navigationController.topViewController is VisitableViewController)
+        assertVisited(url: oneURL, on: .main)
+    }
+
     func test_default_default_default_replaceAction_replacesOnMainStack() {
         let proposal = VisitProposal(action: .replace)
         navigator.route(proposal)
@@ -223,7 +237,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
     }
 
     func test_modal_default_default_dismissesModalThenPushesOnMainStack() {
-        navigationController.pushViewController(routedViewController(url: baseURL.appendingPathComponent("/existing")), animated: false)
+        navigationController.pushViewController(UIViewController(), animated: false)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
 
         navigator.route(VisitProposal(context: .modal))
@@ -362,7 +376,7 @@ final class NavigationHierarchyControllerTests: XCTestCase {
     }
 
     func test_default_any_pop_popsOffMainStack() {
-        navigationController.pushViewController(routedViewController(url: baseURL.appendingPathComponent("/existing")), animated: false)
+        navigationController.pushViewController(UIViewController(), animated: false)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
 
         navigator.route(VisitProposal())
@@ -540,14 +554,6 @@ final class NavigationHierarchyControllerTests: XCTestCase {
             modalNavigationController: modalNavigationController
         )
         return navigator
-    }
-
-    // A view controller stamped with a routed location, standing in for a screen the navigator
-    // has already routed. Identity checks require every stack member to have a location.
-    private func routedViewController(url: URL) -> UIViewController {
-        let viewController = UIViewController()
-        viewController.routedLocation = url
-        return viewController
     }
 
     // Simulate a "real" app so presenting view controllers works under test.


### PR DESCRIPTION
## Summary

Navigation identity checks — `visitingSamePage` (→ replace) and `visitingPreviousPage` (→ pop) in `NavigationHierarchyController` — decided a screen's URL by casting the on-stack controller to `Visitable`/`VisitableViewController` and reading `initialVisitableURL`, falling back to **view-controller type equality** when the cast failed.

That fallback is wrong for custom native view controllers: two instances of the same custom class at different URLs are indistinguishable, so the navigator incorrectly pops or replaces instead of pushing.

This PR makes the **routed location the single source of truth for navigation identity**. The navigator stamps the proposal URL onto every routed controller at route time; the identity checks compare that stamped location and no longer look at the controller's type at all.

This is a direct port of how Hotwire Native **Android** already solves the same problem (see [Parity with Android](#parity-with-android)). It is an alternative to the opt-in protocol approach in #237.

## The change

- New `UIViewController.routedLocation: URL?` — an associated-object property.
- `NavigationHierarchyController.route(controller:proposal:)` stamps `controller.routedLocation = proposal.url` at the single routing choke point (covers the main and modal stacks, push/replace/replaceRoot).
- `visitingSamePage` / `visitingPreviousPage` compare the stamped location via `isSameLocation(as:pathProperties:)`. The candidate-controller `type(of:)` comparison is gone.
- If a stack member has **no** location (a controller placed on the stack without being routed through the navigator — a bug), we `assertionFailure` in debug and return `false` in release, so the visit is treated as a new page and **pushed** (safe: never a wrong pop/replace).

## Parity with Android

Android has always used exactly this model, and this PR converges iOS onto it:

- `NavigatorRule` reads `controller.currentBackStackEntry.location` / `previousBackStackEntry.location`, where `.location` is `arguments?.getString(ARG_LOCATION)` — the location stored in the **back-stack entry's arguments**, stamped at navigation time in `NavigatorRule.withNavArguments()`. It never derives identity from the fragment or its type.
- `locationsAreSame` returns `false` when either side is null → falls through to **push** (the same push-on-miss behavior).
- Android has **no** assertion here, because AndroidX Navigation *owns* the back stack — you navigate to destinations, you never hand it a raw fragment — so an unrouted destination is structurally impossible. UIKit lets anyone `pushViewController(_:)` an arbitrary controller, so the unrouted-controller bug is reachable on iOS. The `assertionFailure` is the iOS-specific guard for a gap Android closes by construction.

## Alternatives considered — identity source

How should the navigator know a screen's URL?

| Approach | Pros | Cons |
|---|---|---|
| **Stamp the location (this PR)** | Zero opt-in; works for any controller (`UIHostingController`, third-party, plain `UIViewController`); single source of truth; matches Android | Location is stored via the ObjC runtime (see storage alternatives below) |
| Opt-in `PathIdentifiable` protocol (#237) | Explicit, compile-checked contract; VC owns its identity | Opt-in — only fixes VCs that conform; the type-equality bug survives for everything else |
| Blanket `extension UIViewController: PathIdentifiable` | No opt-in | **Fatal.** `initialVisitableURL` is non-optional, so a plain VC must return a sentinel URL — and once every VC "conforms," two of them collide on that sentinel and get wrongly treated as the same page (worse than the original bug). Also, a non-`@objc` property declared in a class extension **cannot be overridden by subclasses** (verified: `error: non-'@objc' property 'initialVisitableURL' is declared in extension of 'UIViewController' and cannot be overridden`), so `VisitableViewController` could no longer report its real URL. The `@objc dynamic` escape hatch drags `Visitable` into `@objc` land and still doesn't fix the sentinel problem. |
| Mandatory `acceptCustom(UIViewController & PathIdentifiable)` | Compile-time enforcement; lets the type-equality fallback be deleted as a true invariant | Source-breaking (major version + migration); **breaks alerts** — `acceptCustom` currently carries `UIAlertController` (and could carry a share sheet), which can't sanely be `PathIdentifiable`, forcing an API split (pages vs. presentations); `UIHostingController` can't conform without a subclass; shifts a correctness responsibility onto adopters (a VC can report a URL that disagrees with the proposal that routed it) |
| Base class everyone subclasses | Real stored property; normal dispatch | Single inheritance kills it — SwiftUI's `UIHostingController`, `UITableViewController`, third-party VCs, and apps with their own base class can't all subclass it; undermines the whole point of `acceptCustom(UIViewController)`; still opt-in (remember to subclass) |

We concluded the navigator (which generated the URL) should own it, rather than requiring every custom VC to re-declare a URL the framework already handed it in `handle(proposal:)`.

## Alternatives considered — storage mechanism

Given that we stamp the location onto the controller, how should it be stored? Extensions can't add stored properties to `UIViewController`, so:

| Mechanism | Pros | Cons |
|---|---|---|
| **`objc_setAssociatedObject` (this PR)** | Rides with the controller, so it stays correct through **system-driven stack mutations** (interactive back-swipe, long-press back menu, `popToViewController`); **auto-freed on `dealloc`** — no lifecycle bookkeeping; faithful analog of Android's per-entry arguments bag; a mainstream, Apple-documented idiom | Invisible state via the ObjC runtime; not compile-time discoverable |
| Parallel `[URL]` stack in the navigator | Pure Swift | Desyncs — UIKit mutates the stack (back-swipe, back menu, system pops) without routing through our methods |
| `Dictionary<ObjectIdentifier, URL>` in the navigator | Pure Swift, no ObjC | Leaks unless removed on every exit path; `ObjectIdentifier` is reused after `dealloc`, so a stale entry can match a *different* controller — correctness landmine |
| `NSMapTable` (weak keys) in the navigator | Auto-cleanup on VC dealloc; rides with the controller; keeps storage off `UIViewController` | Lateral move, not cleaner — weak-key reclamation timing is more opaque |

### Why `objc_setAssociatedObject` is the right choice here

1. **Correctness under real UIKit behavior.** The stack can be mutated by the system (back-swipe, back menu, system pops) without passing through the navigator. Storage that rides *with the controller* stays correct; a parallel structure in the navigator desyncs, and an `ObjectIdentifier` map risks matching a reused identity.
2. **No lifecycle bookkeeping.** The value is released automatically when the controller deallocates — no "remember to clean up on pop/dismiss/replace" across many exit paths.
3. **It's the faithful iOS translation of Android's design** — per-entry, framework-managed storage that's freed when the entry leaves the stack. UIKit has no first-class "arguments bag" on a controller; this is the closest equivalent.
4. **It's mainstream, not a hack.** `objc_getAssociatedObject`/`objc_setAssociatedObject` is the canonical, Apple-documented mechanism for attaching state to a class you don't own. It's used across the ecosystem.

The `malloc(1)!` key is deliberate: it's a stable, unique, Swift-6-concurrency-clean key that avoids the `&staticVar` warning. The whole thing is isolated to one small `internal` extension, so the runtime call doesn't leak into the rest of the codebase.

## Design decisions within the chosen approach

- **Stamped location is the *single* source of truth** (we dropped an earlier `Visitable.initialVisitableURL ?? routedLocation` preference). For every controller the framework routes, `initialVisitableURL == routedLocation == proposal.url`, so the preference was redundant on the happy path. Its only effect was to *silently exempt* an unrouted `Visitable` from the "everything on the stack is routed" invariant — but an unrouted `Visitable` bypassed `delegate.visit()` and is itself a bug, so it should trip the assertion like anything else.
- **`assertionFailure` + push, not a hard `precondition`.** A hard trap would crash apps that mix manual UIKit navigation with Hotwire (and would break tests that place a pre-existing screen on the stack). `assertionFailure` flags the bug loudly in development while degrading safely (push) in release.

## Testing

- New regression tests route custom, non-`Visitable` controllers of the same class and assert push / replace / pop by URL. Verified they **fail without the production change** and pass with it (the different-URL and previous-URL cases; the same-URL case guards the collapse invariant).
- Tests that place a pre-existing screen on the stack now stamp it (via a `routedViewController(url:)` helper), reflecting that every stack member is routed.
