### PR TITLE
Move `lazyLoadTabs` from `Hotwire.config` to `HotwireTabBarController` initializer

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -42,7 +42,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Hotwire.config.backButtonDisplayMode = .minimal
         Hotwire.config.showDoneButtonOnModals = true
         Hotwire.config.animateReplaceActions = true
-        Hotwire.config.lazyLoadTabs = true
 #if DEBUG
         Hotwire.config.debugLoggingEnabled = true
 #endif

--- a/Source/HotwireConfig.swift
+++ b/Source/HotwireConfig.swift
@@ -29,16 +29,6 @@ public struct HotwireConfig {
     /// Set to `true` to fade content when performing a `replace` visit.
     public var animateReplaceActions = false
 
-    /// Controls when tab navigators perform their initial visit in `HotwireTabBarController`.
-    ///
-    /// When `true`, only the initially selected tab starts when tabs are loaded; each
-    /// remaining tab starts the first time the user selects it. When `false`, every
-    /// tab starts immediately when `HotwireTabBarController.load(_:)` is called.
-    ///
-    /// This affects when each tab's content is loaded, not whether the tab's
-    /// navigator is created.
-    public var lazyLoadTabs = true
-
     /// Timeout (in seconds) for the request that resolves redirects before a visit.
     public var redirectResolutionTimeout: TimeInterval = 30
 

--- a/Source/Turbo/ViewControllers/HotwireTabBarController.swift
+++ b/Source/Turbo/ViewControllers/HotwireTabBarController.swift
@@ -4,16 +4,35 @@ import UIKit
 ///
 /// This controller loads tabs defined by `HotwireTab` and configures each one with its own `Navigator`.
 /// The currently selected tab's navigator is exposed via the `activeNavigator` property.
+///
+/// By default, tabs are loaded lazily: only the initially selected tab performs its initial
+/// visit when `load(_:)` is called, and each remaining tab performs its initial visit the
+/// first time the user selects it. Pass `lazyLoadTabs: false` in the initializer to load
+/// every tab immediately instead.
 open class HotwireTabBarController: UITabBarController, NavigationHandler {
-    public init(navigatorDelegate: NavigatorDelegate? = nil) {
+    /// Creates a tab bar controller.
+    ///
+    /// - Parameters:
+    ///   - navigatorDelegate: An optional delegate for each tab's `Navigator`.
+    ///   - lazyLoadTabs: Controls when tab navigators perform their initial visit.
+    ///     When `true` (the default), only the initially selected tab starts when tabs
+    ///     are loaded; each remaining tab starts the first time the user selects it.
+    ///     When `false`, every tab starts immediately when `load(_:)` is called.
+    ///     This affects when each tab's content is loaded, not whether the tab's
+    ///     navigator is created.
+    public init(
+        navigatorDelegate: NavigatorDelegate? = nil,
+        lazyLoadTabs: Bool = true
+    ) {
         self.navigatorDelegate = navigatorDelegate
+        self.lazyLoadTabs = lazyLoadTabs
         super.init(nibName: nil, bundle: nil)
         delegate = self
     }
 
     @available(*, unavailable)
     public required init?(coder: NSCoder) {
-        fatalError("Use init(navigatorDelegate:) instead.")
+        fatalError("Use init(navigatorDelegate:lazyLoadTabs:) instead.")
     }
 
     /// The active navigator corresponding to the currently selected tab.
@@ -38,7 +57,7 @@ open class HotwireTabBarController: UITabBarController, NavigationHandler {
         hotwireTabs = tabs
         setupTabs()
 
-        if Hotwire.config.lazyLoadTabs {
+        if lazyLoadTabs {
             activeNavigator.start()
         } else {
             navigatorsByIdentifier.values.forEach { $0.start() }
@@ -69,6 +88,7 @@ open class HotwireTabBarController: UITabBarController, NavigationHandler {
     private var hotwireTabs: [HotwireTab] = []
     private var navigatorsByIdentifier: [HotwireTab.ID: Navigator] = [:]
     private let navigatorDelegate: NavigatorDelegate?
+    private let lazyLoadTabs: Bool
 
     /// Configures each tab for the appropriate platform API.
     private func setupTabs() {


### PR DESCRIPTION
### Summary

This PR moves the `lazyLoadTabs` setting from `Hotwire.config` to a `HotwireTabBarController` initializer parameter.

Lazy tab loading was introduced in [#194](https://github.com/hotwired/hotwire-native-ios/pull/194) as a global config option. Since the behavior is specific to `HotwireTabBarController`, it fits better as an initializer parameter than as library-wide configuration, and this aligns the API shape with Android, where [hotwired/hotwire-native-android#202](https://github.com/hotwired/hotwire-native-android/issues/202) exposes `lazyLoadTabs` as a constructor parameter on `HotwireBottomNavigationController`.

### Notes
The defaults intentionally differ between platforms: iOS defaults to true (lazy loading shipped here as the default), while Android defaults to false (eager loading was its released behavior, so lazy loading is opt-in there).