### PR TITLE
Set `lazyLoadTabs` to `false` by default

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -7,7 +7,10 @@ final class SceneController: UIResponder {
     var window: UIWindow?
 
     private let rootURL = Demo.current
-    private lazy var tabBarController = HotwireTabBarController(navigatorDelegate: self)
+    private lazy var tabBarController = HotwireTabBarController(
+        navigatorDelegate: self,
+        lazyLoadTabs: true
+    )
 
     // MARK: - Authentication
 

--- a/Source/Turbo/ViewControllers/HotwireTabBarController.swift
+++ b/Source/Turbo/ViewControllers/HotwireTabBarController.swift
@@ -5,24 +5,23 @@ import UIKit
 /// This controller loads tabs defined by `HotwireTab` and configures each one with its own `Navigator`.
 /// The currently selected tab's navigator is exposed via the `activeNavigator` property.
 ///
-/// By default, tabs are loaded lazily: only the initially selected tab performs its initial
-/// visit when `load(_:)` is called, and each remaining tab performs its initial visit the
-/// first time the user selects it. Pass `lazyLoadTabs: false` in the initializer to load
-/// every tab immediately instead.
+/// By default, every tab performs its initial visit when `load(_:)` is called. Pass
+/// `lazyLoadTabs: true` in the initializer to defer each tab's initial visit until the
+/// first time the user selects it; the initially selected tab still loads right away.
 open class HotwireTabBarController: UITabBarController, NavigationHandler {
     /// Creates a tab bar controller.
     ///
     /// - Parameters:
     ///   - navigatorDelegate: An optional delegate for each tab's `Navigator`.
     ///   - lazyLoadTabs: Controls when tab navigators perform their initial visit.
-    ///     When `true` (the default), only the initially selected tab starts when tabs
+    ///     When `false` (the default), every tab starts immediately when `load(_:)`
+    ///     is called. When `true`, only the initially selected tab starts when tabs
     ///     are loaded; each remaining tab starts the first time the user selects it.
-    ///     When `false`, every tab starts immediately when `load(_:)` is called.
     ///     This affects when each tab's content is loaded, not whether the tab's
     ///     navigator is created.
     public init(
         navigatorDelegate: NavigatorDelegate? = nil,
-        lazyLoadTabs: Bool = true
+        lazyLoadTabs: Bool = false
     ) {
         self.navigatorDelegate = navigatorDelegate
         self.lazyLoadTabs = lazyLoadTabs


### PR DESCRIPTION
### Summary

This PR changes the default of `HotwireTabBarController`'s `lazyLoadTabs` initializer parameter (introduced in #250) from `true` to `false`, making lazy tab loading opt-in.

Eager loading — every tab performing its initial visit when `load(_:)` is called — is the behavior shipped in 1.2.2 and earlier. The lazy-by-default setting from #194/#250 was never part of a tagged release, so defaulting to `false` preserves released behavior with no breaking changes.

This also aligns the API with Android, where `lazyLoadTabs` on `HotwireBottomNavigationController` defaults to `false` (hotwired/hotwire-native-android#202) — same name, same placement, same default on both platforms.

### Changes

- `lazyLoadTabs` now defaults to `false`; pass `true` to defer each tab's initial visit until the tab is first selected (the initially selected tab still loads right away):

  ```swift
  HotwireTabBarController(lazyLoadTabs: true)
  ```

- Documentation updated to reflect the eager default.
- The demo app opts in to `lazyLoadTabs` to exercise the behavior, matching the Android demo.
