### PR TITLE
Keep bridge destinations active while attached

### DIFF
--- a/Source/Bridge/BridgeDelegate.swift
+++ b/Source/Bridge/BridgeDelegate.swift
@@ -52,7 +52,6 @@ public final class BridgeDelegate: BridgingDelegate {
     public func webViewDidBecomeActive(_ webView: WKWebView) {
         bridge = Bridge.getBridgeFor(webView)
         bridge?.delegate = self
-        destinationIsActive = true
 
         if bridge == nil {
             logger.warning("bridgeNotInitializedForWebView")
@@ -62,7 +61,6 @@ public final class BridgeDelegate: BridgingDelegate {
     public func webViewDidBecomeDeactivated() {
         bridge?.delegate = nil
         bridge = nil
-        destinationIsActive = false
     }
     
     @discardableResult
@@ -84,19 +82,16 @@ public final class BridgeDelegate: BridgingDelegate {
     
     public func onViewDidLoad() {
         logger.debug("[Bridge] bridgeDestinationViewDidLoad: \(self.resolvedLocation)")
-        destinationIsActive = true
         activeComponents.forEach { $0.viewDidLoad() }
     }
     
     public func onViewWillAppear() {
         logger.debug("[Bridge] bridgeDestinationViewWillAppear: \(self.resolvedLocation)")
-        destinationIsActive = true
         activeComponents.forEach { $0.viewWillAppear() }
     }
     
     public func onViewDidAppear() {
         logger.debug("[Bridge] bridgeDestinationViewDidAppear: \(self.resolvedLocation)")
-        destinationIsActive = true
         activeComponents.forEach { $0.viewDidAppear() }
     }
     
@@ -107,7 +102,6 @@ public final class BridgeDelegate: BridgingDelegate {
     
     public func onViewDidDisappear() {
         activeComponents.forEach { $0.viewDidDisappear() }
-        destinationIsActive = false
         logger.debug("[Bridge] bridgeDestinationViewDidDisappear: \(self.resolvedLocation)")
     }
     
@@ -147,8 +141,10 @@ public final class BridgeDelegate: BridgingDelegate {
     // MARK: Private
     
     private var initializedComponents: [String: BridgeComponent] = [:]
-    private var destinationIsActive = false
     private let componentTypes: [BridgeComponent.Type]
+    private var destinationIsActive: Bool {
+        bridge != nil
+    }
     private var resolvedLocation: String {
         webView?.url?.absoluteString ?? location
     }

--- a/Source/Bridge/BridgeDelegate.swift
+++ b/Source/Bridge/BridgeDelegate.swift
@@ -150,7 +150,11 @@ public final class BridgeDelegate: BridgingDelegate {
     }
     
     private var activeComponents: [BridgeComponent] {
-        return initializedComponents.values.filter { _ in destinationIsActive }
+        guard destinationIsActive else {
+            return []
+        }
+
+        return Array(initializedComponents.values)
     }
     
     private func getOrCreateComponent(name: String) -> BridgeComponent? {

--- a/Tests/Bridge/BridgeDelegate+DestinationTests.swift
+++ b/Tests/Bridge/BridgeDelegate+DestinationTests.swift
@@ -57,17 +57,21 @@ class BridgeDelegateDestinationTests: XCTestCase {
         XCTAssertNotNil(component)
     }
 
-    func testBridgeDestinationIsInactiveAfterViewDidDisappear() {
+    func testBridgeDestinationRemainsActiveAfterViewDidDisappearWhenWebViewIsStillActive() {
+        // Tab bar destinations can receive view disappearance callbacks while
+        // their web view remains active and attached to the bridge.
         delegate.onViewDidLoad()
         delegate.onViewDidDisappear()
         delegate.bridgeDidReceiveMessage(.test)
 
         let component: BridgeComponentSpy? = delegate.component()
-        XCTAssertNil(component)
+        XCTAssertNotNil(component)
     }
 
     func testBridgeDestinationIsActiveAfterWebViewDidBecomeActive() {
-        delegate.webViewDidBecomeActive(WKWebView())
+        let webView = WKWebView()
+        Bridge.initialize(webView)
+        delegate.webViewDidBecomeActive(webView)
         delegate.bridgeDidReceiveMessage(.test)
 
         let component: BridgeComponentSpy? = delegate.component()

--- a/Tests/Bridge/BridgeDelegateTests.swift
+++ b/Tests/Bridge/BridgeDelegateTests.swift
@@ -125,7 +125,7 @@ class BridgeDelegateTests: XCTestCase {
         XCTAssertNotNil(component?.delegate)
     }
 
-    func testBridgeIgnoresMessageForInactiveDestination() {
+    func testBridgeIgnoresMessageAfterWebViewBecomesDeactivated() {
         let message = Message(id: "1",
                               component: "one",
                               event: "connect",
@@ -137,7 +137,7 @@ class BridgeDelegateTests: XCTestCase {
         var component: OneBridgeComponent? = delegate.component()
         XCTAssertNotNil(component)
         
-        delegate.onViewDidDisappear()
+        delegate.webViewDidBecomeDeactivated()
         XCTAssertFalse(delegate.bridgeDidReceiveMessage(message))
         
         component = delegate.component()


### PR DESCRIPTION
## Summary

Bridge destinations should remain eligible to receive bridge messages for as long as their web view is still attached to the bridge.

This PR changes `BridgeDelegate` so `destinationIsActive` is derived from bridge ownership (`bridge != nil`) instead of UIKit visibility callbacks. A destination can now receive `viewDidDisappear` and still process bridge messages when its web view is still active, which is the case for tab bar/container-controller flows.

## The bug

`BridgeDelegate` previously treated UIKit visibility as bridge activity:

- `onViewDidLoad`, `onViewWillAppear`, and `onViewDidAppear` set `destinationIsActive = true`.
- `onViewDidDisappear` set `destinationIsActive = false`.
- `bridgeDidReceiveMessage` dropped every message unless `destinationIsActive` was true and the message URL matched the current destination URL.

That makes `viewDidDisappear` a hard bridge cutoff. But UIKit visibility is not the same thing as web view ownership.

In tab bar/container-controller setups, a `VisitableViewController` can receive normal UIKit disappearance callbacks while its web view remains active and attached. If the web page sends a one-shot bridge message during that window, such as a component `connect`, native ignores it as an "inactive" destination even though the bridge is still the correct communication channel.

## Root cause

`destinationIsActive` mixed two different concepts:

1. **Visibility lifecycle**: UIKit view callbacks used to notify already-initialized components about presentation changes.
2. **Bridge lifecycle**: whether this delegate is still attached to the `Bridge` for the active web view and can send/receive messages.

`bridgeDidReceiveMessage` needs the second concept. Using the first creates a race where a valid bridge message can be dropped after `viewDidDisappear` but before the web view/bridge has actually been deactivated.

## The fix

- Stop mutating `destinationIsActive` from view lifecycle callbacks.
- Stop mutating `destinationIsActive` from `webViewDidBecomeActive(_:)` / `webViewDidBecomeDeactivated()` directly.
- Make `destinationIsActive` a computed bridge-ownership check:

  ```swift
  private var destinationIsActive: Bool {
      bridge != nil
  }
  ```

- Keep `webViewDidBecomeDeactivated()` as the real deactivation point by clearing the bridge delegate and niling out the bridge reference.
- Keep `activeComponents` guarded by `destinationIsActive`, but make the guard explicit so components are exposed only while replies can still go through the bridge.

View lifecycle callbacks still forward `viewDidLoad`, `viewWillAppear`, `viewDidAppear`, `viewWillDisappear`, and `viewDidDisappear` to initialized components. They just no longer decide whether future bridge messages are accepted.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Destination appears with active bridge | messages accepted | messages accepted |
| Destination receives `viewDidDisappear` while web view remains attached, e.g. tab/container lifecycle | messages dropped | messages accepted |
| Web view becomes deactivated | messages dropped | messages dropped |
| Bridge is missing for a web view | messages dropped | messages dropped |
