### PR TITLE
Route modal-to-default redirects after the modal dismissal completes

### DIFF
--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -76,6 +76,15 @@ class NavigationHierarchyController {
         }
     }
 
+    func dismissModal(animated: Bool, completion: (() -> Void)? = nil) {
+        guard navigationController.presentedViewController != nil else {
+            completion?()
+            return
+        }
+
+        navigationController.dismiss(animated: animated, completion: completion)
+    }
+
     func clearAll(animated: Bool) {
         navigationController.dismiss(animated: animated)
         navigationController.popToRootViewController(animated: animated)

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -183,6 +183,14 @@ extension Navigator: SessionDelegate {
             // controller is orphaned on the stack it was pushed onto.
             let sessionIsModal = session === modalSession
             let proposalIsModal = proposal.context == .modal
+
+            if sessionIsModal && !proposalIsModal {
+                hierarchyController.dismissModal(animated: true) { [weak self] in
+                    self?.route(proposal)
+                }
+                return
+            }
+
             if sessionIsModal != proposalIsModal {
                 // Animate the pop only when receding from the active modal session
                 // to the default context, matching the back-style transition.

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -585,7 +585,64 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         XCTAssertNil(navigationController.presentedViewController)
     }
 
+    func test_redirect_modalToMain_singleControllerModal_routesAfterModalDismissalCompletes() {
+        assertModalToMainRedirectWaitsForDismissal(
+            modalProposals: [VisitProposal(path: "/modal-one", context: .modal)]
+        )
+    }
+
+    func test_redirect_modalToMain_multipleControllerModal_routesAfterModalDismissalCompletes() {
+        assertModalToMainRedirectWaitsForDismissal(
+            modalProposals: [
+                VisitProposal(path: "/modal-one", context: .modal),
+                VisitProposal(path: "/modal-two", context: .modal)
+            ]
+        )
+    }
+
     // MARK: Private
+
+    private func assertModalToMainRedirectWaitsForDismissal(modalProposals: [VisitProposal]) {
+        let delayedNavigationController = DelayedDismissalNavigationController()
+        let testModalNavigationController = TestableNavigationController()
+        let redirectDelegate = RedirectProposalRecordingDelegate()
+        let testSession = Session(webView: Hotwire.config.makeWebView())
+        let testModalSession = Session(webView: Hotwire.config.makeWebView())
+        let testNavigator = Navigator(
+            session: testSession,
+            modalSession: testModalSession,
+            delegate: redirectDelegate,
+            configuration: .init(name: "Test", startLocation: oneURL)
+        )
+        testNavigator.hierarchyController = NavigationHierarchyController(
+            delegate: testNavigator,
+            navigationController: delayedNavigationController,
+            modalNavigationController: testModalNavigationController
+        )
+        loadNavigationControllerInWindow(delayedNavigationController)
+
+        testNavigator.route(oneURL)
+        for proposal in modalProposals {
+            testNavigator.route(proposal)
+        }
+
+        let redirect = VisitProposal(path: "/three", action: .replace, context: .default, redirected: true)
+        testNavigator.session(testModalSession, didProposeVisit: redirect)
+
+        XCTAssertTrue(redirectDelegate.redirectProposals.isEmpty)
+        XCTAssertIdentical(delayedNavigationController.presentedViewController, testModalNavigationController)
+
+        delayedNavigationController.completeDismissal()
+
+        XCTAssertEqual(redirectDelegate.redirectProposals.count, 1)
+        let receivedProposal = redirectDelegate.redirectProposals[0]
+        XCTAssertEqual(receivedProposal.url, redirect.url)
+        XCTAssertEqual(receivedProposal.options.action, redirect.options.action)
+        XCTAssertEqual(receivedProposal.context, redirect.context)
+        XCTAssertEqual(receivedProposal.isRedirect, redirect.isRedirect)
+        XCTAssertNil(delayedNavigationController.presentedViewController)
+        XCTAssertEqual(testNavigator.session.activeVisitable?.initialVisitableURL, redirect.url)
+    }
 
     private enum Context {
         case main, modal
@@ -627,6 +684,10 @@ final class NavigationHierarchyControllerTests: XCTestCase {
 
     // Simulate a "real" app so presenting view controllers works under test.
     private func loadNavigationControllerInWindow() {
+        loadNavigationControllerInWindow(navigationController)
+    }
+
+    private func loadNavigationControllerInWindow(_ navigationController: UINavigationController) {
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
         navigationController.loadViewIfNeeded()
@@ -697,5 +758,35 @@ private final class CustomViewController: UIViewController {}
 private class CustomViewControllerDelegate: NavigatorDelegate {
     func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
         .acceptCustom(CustomViewController())
+    }
+}
+
+// MARK: - RedirectProposalRecordingDelegate
+
+private final class RedirectProposalRecordingDelegate: NavigatorDelegate {
+    private(set) var redirectProposals = [VisitProposal]()
+
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
+        if proposal.isRedirect {
+            redirectProposals.append(proposal)
+        }
+
+        return .accept
+    }
+}
+
+// MARK: - DelayedDismissalNavigationController
+
+private final class DelayedDismissalNavigationController: TestableNavigationController {
+    private var dismissalCompletion: (() -> Void)?
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissalCompletion = completion
+    }
+
+    func completeDismissal() {
+        presentedViewController = nil
+        dismissalCompletion?()
+        dismissalCompletion = nil
     }
 }

--- a/Tests/Turbo/Navigator/TestableNavigationController.swift
+++ b/Tests/Turbo/Navigator/TestableNavigationController.swift
@@ -4,6 +4,8 @@ import UIKit
 /// Manipulate a navigation controller under test.
 /// Ensures `viewControllers` is updated synchronously.
 /// Manages `presentedViewController` directly because it isn't updated on the same thread.
+/// Invokes the dismissal completion synchronously because UIKit never finishes a
+/// presentation transition in a test bundle, so it would otherwise drop the completion.
 class TestableNavigationController: HotwireNavigationController {
     override var presentedViewController: UIViewController? {
         get { _presentedViewController }
@@ -33,7 +35,8 @@ class TestableNavigationController: HotwireNavigationController {
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         _presentedViewController = nil
-        super.dismiss(animated: false, completion: completion)
+        super.dismiss(animated: false, completion: nil)
+        completion?()
     }
 
     // MARK: Private


### PR DESCRIPTION
Since 1453caf, `session(_:didProposeVisit:)` pops the modal for a redirect that crosses from the modal session to the default context and then routes the proposal synchronously. The navigator delegate is therefore consulted while the dismissal transition is still in flight, and delegates that key off presentation state can drop the proposal — in HEY iOS this swallowed the post-form redirect entirely, leaving a stale web view on screen (Screener "Clear all").

This defers routing until the dismissal actually completes: `NavigationHierarchyController.dismissModal(animated:completion:)` dismisses the entire modal stack (dismiss, not pop — multi-controller modal stacks are covered) and invokes its completion immediately when nothing is presented; the modal-to-default redirect proposal is routed from that completion. Delegates now always see a settled hierarchy.

**To verify**
- New tests cover the deferred route for one- and multi-controller modal stacks, asserting the original proposal reaches the delegate only after dismissal completes.
- `TestableNavigationController` now honors the dismiss-completion contract itself (UIKit never finishes a presentation transition in a test bundle, so forwarding the completion to `super` silently dropped it) — that's the `fixup!` commit, to be autosquashed before this leaves draft.
- Full suite: 368/368 on iOS Simulator.

**Compatibility notes**
- Modal-to-default redirects now route after the dismissal animation instead of synchronously — a new async seam for code that relied on the old ordering.
- Default-to-modal and same-context redirects deliberately keep their current order.

Draft pending review and autosquash.