### PR TITLE
Route modal-to-default redirects after the modal dismissal completes

### DIFF
--- a/Source/Turbo/Navigator/NavigationHierarchyController.swift
+++ b/Source/Turbo/Navigator/NavigationHierarchyController.swift
@@ -76,6 +76,15 @@ class NavigationHierarchyController {
         }
     }
 
+    func dismissModal(animated: Bool, completion: (() -> Void)? = nil) {
+        guard navigationController.presentedViewController != nil else {
+            completion?()
+            return
+        }
+
+        navigationController.dismiss(animated: animated, completion: completion)
+    }
+
     func clearAll(animated: Bool) {
         navigationController.dismiss(animated: animated)
         navigationController.popToRootViewController(animated: animated)

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -183,6 +183,14 @@ extension Navigator: SessionDelegate {
             // controller is orphaned on the stack it was pushed onto.
             let sessionIsModal = session === modalSession
             let proposalIsModal = proposal.context == .modal
+
+            if sessionIsModal && !proposalIsModal {
+                hierarchyController.dismissModal(animated: true) { [weak self] in
+                    self?.route(proposal)
+                }
+                return
+            }
+
             if sessionIsModal != proposalIsModal {
                 // Animate the pop only when receding from the active modal session
                 // to the default context, matching the back-style transition.

--- a/Source/Turbo/Navigator/Navigator.swift
+++ b/Source/Turbo/Navigator/Navigator.swift
@@ -184,18 +184,16 @@ extension Navigator: SessionDelegate {
             let sessionIsModal = session === modalSession
             let proposalIsModal = proposal.context == .modal
 
-            if sessionIsModal && !proposalIsModal {
+            switch (sessionIsModal, proposalIsModal) {
+            case (true, false):
                 hierarchyController.dismissModal(animated: true) { [weak self] in
                     self?.route(proposal)
                 }
                 return
-            }
-
-            if sessionIsModal != proposalIsModal {
-                // Animate the pop only when receding from the active modal session
-                // to the default context, matching the back-style transition.
-                let animatePop = sessionIsModal && proposal.context == .default
-                pop(animated: animatePop)
+            case (false, true):
+                pop(animated: false)
+            default:
+                break
             }
         }
         route(proposal)

--- a/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
+++ b/Tests/Turbo/Navigator/NavigationHierarchyControllerTests.swift
@@ -585,7 +585,64 @@ final class NavigationHierarchyControllerTests: XCTestCase {
         XCTAssertNil(navigationController.presentedViewController)
     }
 
+    func test_redirect_modalToMain_singleControllerModal_routesAfterModalDismissalCompletes() {
+        assertModalToMainRedirectWaitsForDismissal(
+            modalProposals: [VisitProposal(path: "/modal-one", context: .modal)]
+        )
+    }
+
+    func test_redirect_modalToMain_multipleControllerModal_routesAfterModalDismissalCompletes() {
+        assertModalToMainRedirectWaitsForDismissal(
+            modalProposals: [
+                VisitProposal(path: "/modal-one", context: .modal),
+                VisitProposal(path: "/modal-two", context: .modal)
+            ]
+        )
+    }
+
     // MARK: Private
+
+    private func assertModalToMainRedirectWaitsForDismissal(modalProposals: [VisitProposal]) {
+        let delayedNavigationController = DelayedDismissalNavigationController()
+        let testModalNavigationController = TestableNavigationController()
+        let redirectDelegate = RedirectProposalRecordingDelegate()
+        let testSession = Session(webView: Hotwire.config.makeWebView())
+        let testModalSession = Session(webView: Hotwire.config.makeWebView())
+        let testNavigator = Navigator(
+            session: testSession,
+            modalSession: testModalSession,
+            delegate: redirectDelegate,
+            configuration: .init(name: "Test", startLocation: oneURL)
+        )
+        testNavigator.hierarchyController = NavigationHierarchyController(
+            delegate: testNavigator,
+            navigationController: delayedNavigationController,
+            modalNavigationController: testModalNavigationController
+        )
+        loadNavigationControllerInWindow(delayedNavigationController)
+
+        testNavigator.route(oneURL)
+        for proposal in modalProposals {
+            testNavigator.route(proposal)
+        }
+
+        let redirect = VisitProposal(path: "/three", action: .replace, context: .default, redirected: true)
+        testNavigator.session(testModalSession, didProposeVisit: redirect)
+
+        XCTAssertTrue(redirectDelegate.redirectProposals.isEmpty)
+        XCTAssertIdentical(delayedNavigationController.presentedViewController, testModalNavigationController)
+
+        delayedNavigationController.completeDismissal()
+
+        XCTAssertEqual(redirectDelegate.redirectProposals.count, 1)
+        let receivedProposal = redirectDelegate.redirectProposals[0]
+        XCTAssertEqual(receivedProposal.url, redirect.url)
+        XCTAssertEqual(receivedProposal.options.action, redirect.options.action)
+        XCTAssertEqual(receivedProposal.context, redirect.context)
+        XCTAssertEqual(receivedProposal.isRedirect, redirect.isRedirect)
+        XCTAssertNil(delayedNavigationController.presentedViewController)
+        XCTAssertEqual(testNavigator.session.activeVisitable?.initialVisitableURL, redirect.url)
+    }
 
     private enum Context {
         case main, modal
@@ -627,6 +684,10 @@ final class NavigationHierarchyControllerTests: XCTestCase {
 
     // Simulate a "real" app so presenting view controllers works under test.
     private func loadNavigationControllerInWindow() {
+        loadNavigationControllerInWindow(navigationController)
+    }
+
+    private func loadNavigationControllerInWindow(_ navigationController: UINavigationController) {
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
         navigationController.loadViewIfNeeded()
@@ -697,5 +758,35 @@ private final class CustomViewController: UIViewController {}
 private class CustomViewControllerDelegate: NavigatorDelegate {
     func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
         .acceptCustom(CustomViewController())
+    }
+}
+
+// MARK: - RedirectProposalRecordingDelegate
+
+private final class RedirectProposalRecordingDelegate: NavigatorDelegate {
+    private(set) var redirectProposals = [VisitProposal]()
+
+    func handle(proposal: VisitProposal, from navigator: Navigator) -> ProposalResult {
+        if proposal.isRedirect {
+            redirectProposals.append(proposal)
+        }
+
+        return .accept
+    }
+}
+
+// MARK: - DelayedDismissalNavigationController
+
+private final class DelayedDismissalNavigationController: TestableNavigationController {
+    private var dismissalCompletion: (() -> Void)?
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissalCompletion = completion
+    }
+
+    func completeDismissal() {
+        presentedViewController = nil
+        dismissalCompletion?()
+        dismissalCompletion = nil
     }
 }

--- a/Tests/Turbo/Navigator/TestableNavigationController.swift
+++ b/Tests/Turbo/Navigator/TestableNavigationController.swift
@@ -4,6 +4,8 @@ import UIKit
 /// Manipulate a navigation controller under test.
 /// Ensures `viewControllers` is updated synchronously.
 /// Manages `presentedViewController` directly because it isn't updated on the same thread.
+/// Invokes the dismissal completion synchronously because UIKit never finishes a
+/// presentation transition in a test bundle, so it would otherwise drop the completion.
 class TestableNavigationController: HotwireNavigationController {
     override var presentedViewController: UIViewController? {
         get { _presentedViewController }
@@ -33,7 +35,8 @@ class TestableNavigationController: HotwireNavigationController {
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         _presentedViewController = nil
-        super.dismiss(animated: false, completion: completion)
+        super.dismiss(animated: false, completion: nil)
+        completion?()
     }
 
     // MARK: Private


### PR DESCRIPTION
Related: https://app.basecamp.com/2914079/buckets/43795599/card_tables/cards/10152469020
Verified via basecamp/hey-ios#1657, which pins HEY Email to this branch for the manual gate.

Since 1453caf, a modal-to-default redirect routes while the navigator is still dismissing the modal. The delegate gets consulted mid-transition, so a delegate that looks at what's presented sees a half-dismissed hierarchy and can turn the proposal down — that's how HEY iOS lost a post-form redirect, leaving a stale list on screen.

Routing now waits for the dismissal to finish. Other redirect transitions keep their current order.

Replaces #260, reverted because it merged before a consuming app had verified it.

## Reproduction

**On `bridge-delegate-destination-lifecycle`, the bug is reproducible:**
1. In a consuming app whose delegate inspects presentation state (HEY iOS), open a web modal whose form POST redirects to a default-context location — Screener → "Clear all…" → the confirm page.
2. Submit the form. The modal dismisses, but the redirect never routes — the screen beneath still shows the pre-submit list.

**On this branch, it's fixed:**
1. Pin the app to `ab9b9cc` (basecamp/hey-ios#1657 does this) and repeat. The modal dismisses, then the redirect routes — you land on the Imbox, and the Screener is empty on re-entry.

**Without the GUI:** run the `NavigationHierarchyControllerTests` class — `test_redirect_modalToMain_dismissesModalAndRoutesOntoMainStack` holds the dismissal completion and asserts the original proposal routes only after it fires.